### PR TITLE
misc. cleanup

### DIFF
--- a/src/software/amazon/ionschema/Constraint.kt
+++ b/src/software/amazon/ionschema/Constraint.kt
@@ -10,11 +10,5 @@ interface Constraint {
      * Returns the name of the constraint.
      */
     fun name(): String
-
-    /**
-     * Checks this constraint against the provided value,
-     * adding [Violation]s and/or [ViolationChild]ren to issues
-     * if the constraint is violated.
-     */
-    fun validate(value: IonValue, issues: Violations)
 }
+

--- a/src/software/amazon/ionschema/Type.kt
+++ b/src/software/amazon/ionschema/Type.kt
@@ -1,19 +1,19 @@
 package software.amazon.ionschema
 
 import software.amazon.ion.IonValue
-import software.amazon.ionschema.internal.TypeInternal
+import software.amazon.ionschema.internal.ConstraintInternal
 
 /**
  * An Ion Schema Type is defined by an optional name and zero or more
  * [Constraints].  Unless otherwise specified, the constraint `type: any`
  * is automatically applied.
  */
-interface Type {
+interface Type : Constraint {
     /**
      * Returns the name of the type;  if the type has no name, a string representing
      * the definition of the type is returned.
      */
-    fun name(): String
+    override fun name(): String
 
     /**
      * If the specified value violates one or more of this type's constraints,
@@ -33,10 +33,11 @@ interface Type {
                 shortCircuit = shortCircuit,
                 childrenAllowed = false)
         try {
-            (type as TypeInternal).validate(value, violations)
+            (type as ConstraintInternal).validate(value, violations)
         } catch (e: ShortCircuitValidationException) {
             // short-circuit validation winds up here, safe to ignore
         }
         return violations
     }
 }
+

--- a/src/software/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/src/software/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -56,7 +56,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
             Constraints.scale               -> Scale(ion)
             Constraints.timestamp_offset    -> TimestampOffset(ion)
             Constraints.timestamp_precision -> TimestampPrecision(ion)
-            Constraints.type                -> TypeReference(ion, schema)
+            Constraints.type                -> TypeReference.create(ion, schema)
             Constraints.valid_values        -> ValidValues(ion)
         }
 }

--- a/src/software/amazon/ionschema/internal/ConstraintInternal.kt
+++ b/src/software/amazon/ionschema/internal/ConstraintInternal.kt
@@ -1,0 +1,17 @@
+package software.amazon.ionschema.internal
+
+import software.amazon.ion.IonValue
+import software.amazon.ionschema.Constraint
+import software.amazon.ionschema.Violations
+
+internal interface ConstraintInternal : Constraint {
+    val ion: IonValue
+
+    /**
+     * Checks this constraint against the provided value,
+     * adding [Violation]s and/or [ViolationChild]ren to issues
+     * if the constraint is violated.
+     */
+    fun validate(value: IonValue, issues: Violations)
+}
+

--- a/src/software/amazon/ionschema/internal/TypeBuiltinImpl.kt
+++ b/src/software/amazon/ionschema/internal/TypeBuiltinImpl.kt
@@ -1,10 +1,32 @@
 package software.amazon.ionschema.internal
 
 import software.amazon.ion.IonStruct
+import software.amazon.ion.IonValue
 import software.amazon.ionschema.Schema
+import software.amazon.ionschema.Violation
+import software.amazon.ionschema.Violations
+import software.amazon.ionschema.internal.constraint.ConstraintBase
 
 // represents built-in types that are defined in terms of other built-in types
-internal class TypeBuiltinImpl constructor (
-        ionStruct: IonStruct,
-        schema: Schema
-) : TypeInternal by TypeImpl(ionStruct, schema, addDefaultTypeConstraint = false)
+internal class TypeBuiltinImpl private constructor(
+        private val ionStruct: IonStruct,
+        private val delegate: TypeInternal
+) : TypeInternal by delegate, ConstraintBase(ionStruct), TypeBuiltin {
+
+    constructor (ionStruct: IonStruct, schema: Schema)
+            : this(ionStruct, TypeImpl(ionStruct, schema, addDefaultTypeConstraint = false))
+
+    override fun name() = ionStruct.fieldName
+
+    override fun validate(value: IonValue, issues: Violations) {
+        val struct = ion.system.newEmptyStruct()
+        struct.put("type", ion.system.newSymbol(name()))
+        val violation = Violation(struct, "type_mismatch")
+        (delegate as ConstraintInternal).validate(value, violation)
+        if (!violation.isValid()) {
+            violation.message = "expected type %s".format(name())
+            issues.add(violation)
+        }
+    }
+}
+

--- a/src/software/amazon/ionschema/internal/TypeImpl.kt
+++ b/src/software/amazon/ionschema/internal/TypeImpl.kt
@@ -35,7 +35,7 @@ internal class TypeImpl(
 
         if (!foundTypeConstraint && addDefaultTypeConstraint) {
             // default type is 'any':
-            tmpConstraints.add(TypeReference(ANY, schema))
+            tmpConstraints.add(TypeReference.create(ANY, schema))
         }
 
         constraints = tmpConstraints.toList()
@@ -57,7 +57,7 @@ internal class TypeImpl(
 
     override fun validate(value: IonValue, issues: Violations) {
         constraints.forEach {
-            it.validate(value, issues)
+            (it as ConstraintInternal).validate(value, issues)
         }
     }
 }

--- a/src/software/amazon/ionschema/internal/TypeInline.kt
+++ b/src/software/amazon/ionschema/internal/TypeInline.kt
@@ -5,21 +5,25 @@ import software.amazon.ion.IonValue
 import software.amazon.ionschema.Schema
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
+import software.amazon.ionschema.internal.constraint.ConstraintBase
 
 internal class TypeInline private constructor (
         private val ionStruct: IonStruct,
         private val type: TypeInternal
-) : TypeInternal by type {
+) : ConstraintBase(ionStruct), TypeInternal by type {
 
     constructor(ionStruct: IonStruct, schema: Schema)
             : this(ionStruct, TypeImpl(ionStruct, schema))
 
+    override fun name() = type.name()
+
     override fun validate(value: IonValue, issues: Violations) {
         val violation = Violation(ionStruct, "type_mismatch")
-        type.validate(value, violation)
+        (type as ConstraintInternal).validate(value, violation)
         if (!violation.isValid()) {
             violation.message = "expected type %s".format(name())
             issues.add(violation)
         }
     }
 }
+

--- a/src/software/amazon/ionschema/internal/TypeInternal.kt
+++ b/src/software/amazon/ionschema/internal/TypeInternal.kt
@@ -2,10 +2,8 @@ package software.amazon.ionschema.internal
 
 import software.amazon.ion.IonValue
 import software.amazon.ionschema.Type
-import software.amazon.ionschema.Violations
 
 internal interface TypeInternal : Type {
     fun isValidForBaseType(value: IonValue): Boolean
-
-    fun validate(value: IonValue, issues: Violations)
 }
+

--- a/src/software/amazon/ionschema/internal/TypeNamed.kt
+++ b/src/software/amazon/ionschema/internal/TypeNamed.kt
@@ -15,7 +15,7 @@ internal class TypeNamed(
         val struct = ion.system.newEmptyStruct()
         struct.put("type", ion.clone())
         val violation = Violation(struct, "type_mismatch")
-        type.validate(value, violation)
+        (type as ConstraintInternal).validate(value, violation)
         if (!violation.isValid()) {
             violation.message = "expected type %s".format(name())
             issues.add(violation)

--- a/src/software/amazon/ionschema/internal/TypeNullable.kt
+++ b/src/software/amazon/ionschema/internal/TypeNullable.kt
@@ -13,7 +13,7 @@ internal class TypeNullable(
     override fun validate(value: IonValue, issues: Violations) {
         if (!(value.isNullValue
                     && (value.type == IonType.NULL || type.isValidForBaseType(value)))) {
-            type.validate(value, issues)
+            (type as ConstraintInternal).validate(value, issues)
         }
     }
 

--- a/src/software/amazon/ionschema/internal/constraint/Annotations.kt
+++ b/src/software/amazon/ionschema/internal/constraint/Annotations.kt
@@ -3,20 +3,20 @@ package software.amazon.ionschema.internal.constraint
 import software.amazon.ion.IonList
 import software.amazon.ion.IonSymbol
 import software.amazon.ion.IonValue
-import software.amazon.ionschema.Constraint
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
+import software.amazon.ionschema.internal.ConstraintInternal
 import software.amazon.ionschema.internal.util.withoutTypeAnnotations
 
 internal class Annotations private constructor(
-        ion: IonValue,
-        private val delegate: Constraint
-) : ConstraintBase(ion), Constraint by delegate {
+        override val ion: IonValue,
+        private val delegate: ConstraintInternal
+) : ConstraintBase(ion), ConstraintInternal by delegate {
 
     constructor(ion: IonValue) : this(ion, delegate(ion))
 
     companion object {
-        private fun delegate(ion: IonValue): Constraint {
+        private fun delegate(ion: IonValue): ConstraintInternal {
             val requiredByDefault = ion.hasTypeAnnotation("required")
             val annotations = (ion as IonList).map {
                 Annotation(it as IonSymbol, requiredByDefault)

--- a/src/software/amazon/ionschema/internal/constraint/ConstraintBase.kt
+++ b/src/software/amazon/ionschema/internal/constraint/ConstraintBase.kt
@@ -1,18 +1,14 @@
 package software.amazon.ionschema.internal.constraint
 
 import software.amazon.ion.IonValue
-import software.amazon.ionschema.Constraint
+import software.amazon.ionschema.internal.ConstraintInternal
 
 internal abstract class ConstraintBase(
-        internal val ion: IonValue
-    ) : Constraint {
+        override val ion: IonValue
+) : ConstraintInternal {
 
     override fun name() = ion.fieldName
 
-    override fun toString(): String {
-        val sb = StringBuilder()
-        //sb.append(name()).append(": ")
-        sb.append(ion)
-        return sb.toString()
-    }
+    override fun toString() = ion.toString()
 }
+

--- a/src/software/amazon/ionschema/internal/constraint/Element.kt
+++ b/src/software/amazon/ionschema/internal/constraint/Element.kt
@@ -7,13 +7,14 @@ import software.amazon.ionschema.ViolationChild
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
 import software.amazon.ionschema.CommonViolations
+import software.amazon.ionschema.internal.ConstraintInternal
 
 internal class Element(
         ion: IonValue,
         schema: Schema
     ) : ConstraintBase(ion) {
 
-    private val typeReference = TypeReference(ion, schema, isField = true)
+    private val typeReference = TypeReference.create(ion, schema, isField = true)
 
     override fun validate(value: IonValue, issues: Violations) {
         if (value !is IonContainer) {
@@ -28,7 +29,7 @@ internal class Element(
                     } else {
                         ViolationChild(fieldName = it.fieldName, value = it)
                     }
-                typeReference.validate(it, elementValidation)
+                (typeReference as ConstraintInternal).validate(it, elementValidation)
                 if (!elementValidation.isValid()) {
                     elementIssues.add(elementValidation)
                 }

--- a/src/software/amazon/ionschema/internal/constraint/LogicConstraints.kt
+++ b/src/software/amazon/ionschema/internal/constraint/LogicConstraints.kt
@@ -6,19 +6,20 @@ import software.amazon.ionschema.Schema
 import software.amazon.ionschema.Type
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
+import software.amazon.ionschema.internal.ConstraintInternal
 
 internal abstract class LogicConstraints(
         ion: IonValue,
         schema: Schema
     ) : ConstraintBase(ion) {
 
-    internal val types = (ion as IonList).map { TypeReference(it, schema) }
+    internal val types = (ion as IonList).map { TypeReference.create(it, schema) }
 
     internal fun validateTypes(value: IonValue, issues: Violations): List<Type> {
         val validTypes = mutableListOf<Type>()
         types.forEach {
             val checkpoint = issues.checkpoint()
-            it.validate(value, issues)
+            (it as ConstraintInternal).validate(value, issues)
             if (checkpoint.isValid()) {
                 validTypes.add(it)
             }
@@ -62,7 +63,7 @@ internal class OneOf(ion: IonValue, schema: Schema) : LogicConstraints(ion, sche
                 oneOfViolation.message = "value matches %s types, expected 1".format(validTypes.size)
 
                 validTypes.forEach {
-                    val typeDef = (it as ConstraintBase).ion
+                    val typeDef = (it as ConstraintInternal).ion
                     oneOfViolation.add(
                             Violation(typeDef, "type_matched",
                                     "value matches type %s".format(typeDef)))
@@ -74,13 +75,14 @@ internal class OneOf(ion: IonValue, schema: Schema) : LogicConstraints(ion, sche
 }
 
 internal class Not(ion: IonValue, schema: Schema) : ConstraintBase(ion) {
-    private val type = TypeReference(ion, schema)
+    private val type = TypeReference.create(ion, schema)
 
     override fun validate(value: IonValue, issues: Violations) {
         val child = Violation(ion, "type_matched", "value unexpectedly matches type")
-        type.validate(value, child)
+        (type as ConstraintInternal).validate(value, child)
         if (child.isValid()) {
             issues.add(child)
         }
     }
 }
+

--- a/src/software/amazon/ionschema/internal/constraint/Occurs.kt
+++ b/src/software/amazon/ionschema/internal/constraint/Occurs.kt
@@ -9,6 +9,8 @@ import software.amazon.ionschema.Schema
 import software.amazon.ionschema.ViolationChild
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
+import software.amazon.ionschema.internal.ConstraintInternal
+import software.amazon.ionschema.internal.TypeInternal
 import software.amazon.ionschema.internal.util.Range
 import software.amazon.ionschema.internal.util.RangeFactory
 import software.amazon.ionschema.internal.util.RangeIntNonNegative
@@ -35,7 +37,7 @@ internal class Occurs(
 
     internal val range: Range<Int>
     internal val occursIon: IonValue
-    private val typeReference: TypeReference
+    private val typeReference: TypeInternal
     private var attempts = 0
     internal var validCount = 0
     private val values = ion.system.newEmptyList()
@@ -68,7 +70,7 @@ internal class Occurs(
         if (ion is IonStruct && occurs != null) {
             tmpIon = ion.cloneAndRemove("occurs")
         }
-        typeReference = TypeReference(tmpIon, schema, isField)
+        typeReference = TypeReference.create(tmpIon, schema, isField)
 
         occursIon = if (occurs != null) {
                 occurs
@@ -84,7 +86,7 @@ internal class Occurs(
     override fun validate(value: IonValue, issues: Violations) {
         attempts++
 
-        typeReference.validate(value, issues)
+        (typeReference as ConstraintInternal).validate(value, issues)
         validCount = attempts - issues.violations.size
         (issues as ViolationChild).addValue(value)
 


### PR DESCRIPTION
- introduces ConstraintInternal interface
- moves Constraint.validate(IonValue, Violations) and TypeInternal.vlaidate(IonValue, Violations) to ConstraintInternal
- changes TypeReference class to factory method
- updates TypeBuiltinImpl to actually implement TypeBuiltin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
