### PR TITLE
adds tests to assert expected schema behavior

### DIFF
--- a/data/test/schema/Customer.isl
+++ b/data/test/schema/Customer.isl
@@ -1,9 +1,8 @@
 schema_header::{
-    imports: [
-        { id: "schema/CommonTypes.isl", type: positive_int }
-    ],
+  imports: [
+    { id: "schema/util/positive_int.isl", type: positive_int }
+  ],
 }
-
 type::{
   name: Customer,
   type: struct,
@@ -14,7 +13,6 @@ type::{
     age: { type: positive_int },
   }
 }
-
 schema_footer::{
 }
 
@@ -32,3 +30,4 @@ invalid::{
     { firstName: "Phil", lastName: "Collins", age: -1 },
   ],
 }
+

--- a/data/test/schema/import/abcde.isl
+++ b/data/test/schema/import/abcde.isl
@@ -1,0 +1,8 @@
+schema_header::{}
+type::{ name: a, valid_values: [a, "a"] }
+type::{ name: b, valid_values: [b, "b"] }
+type::{ name: c, valid_values: [c, "c"] }
+type::{ name: d, valid_values: [d, "d"] }
+type::{ name: e, valid_values: [e, "e"] }
+schema_footer::{}
+

--- a/data/test/schema/import/import.isl
+++ b/data/test/schema/import/import.isl
@@ -1,0 +1,35 @@
+schema_header::{
+  imports: [
+    { id: "schema/import/abcde.isl" },
+  ],
+}
+type::{
+  name: import_test,
+  ordered_elements: [ a, b, c, d, e ],
+}
+schema_footer::{}
+
+valid::{
+  import_test: [
+    [a, "b", c, "d", e],
+    ("a" b "c" d "e"),
+    document::'''a b c d e''',
+  ],
+  a: [a, "a"],
+  b: [b, "b"],
+  c: [c, "c"],
+  d: [d, "d"],
+  e: [e, "e"],
+}
+invalid::{
+  import_test: [
+    [a, b, c, d],
+    [a, b, c, d, e, f],
+  ],
+  a: [   "b", c, "d", e],
+  b: [a,      c, "d", e],
+  c: [a, "b",    "d", e],
+  d: [a, "b", c,      e],
+  e: [a, "b", c, "d",  ],
+}
+

--- a/data/test/schema/import/import_type.isl
+++ b/data/test/schema/import/import_type.isl
@@ -1,0 +1,31 @@
+schema_header::{
+  imports: [
+    { id: "schema/util/positive_int.isl", type: positive_int }
+  ],
+}
+type::{
+  name: import_type_test,
+  element: positive_int,
+}
+schema_footer::{
+}
+
+valid::{
+  import_type_test: [
+    [1, 2, 3],
+    (1 2 3),
+    { a: 1, b: 2, c: 3 },
+    document::"1 2 3",
+  ],
+}
+
+invalid::{
+  import_type_test: [
+    [0],
+    (-1),
+    { a: 0.0 },
+    document::"0",
+    document::"hi",
+  ],
+}
+

--- a/data/test/schema/import/import_type_by_alias.isl
+++ b/data/test/schema/import/import_type_by_alias.isl
@@ -1,0 +1,33 @@
+schema_header::{
+  imports: [
+    { id: "schema/util/positive_int.isl", type: positive_int, as: positive_int_1 },
+    { id: "schema/util/positive_int.isl", type: positive_int, as: positive_int_2 },
+  ],
+}
+type::{
+  name: import_type_by_alias_test,
+  ordered_elements: [
+    positive_int_1,
+    positive_int_2,
+  ],
+}
+schema_footer::{
+}
+
+valid::{
+  import_type_by_alias_test: [
+    [1, 2],
+    (1 2),
+    document::"1 2",
+  ],
+}
+
+invalid::{
+  import_type_by_alias_test: [
+    [0, 0],
+    (-1 -1),
+    document::"0 0",
+    document::"1 hi",
+  ],
+}
+

--- a/data/test/schema/import/invalid.isl
+++ b/data/test/schema/import/invalid.isl
@@ -1,0 +1,22 @@
+// duplicate import:
+invalid_schema::document::'''
+  schema_header::{
+    imports: [
+      { id: "schema/util/positive_int.isl" },
+      { id: "schema/util/positive_int.isl" },
+    ],
+  }
+  schema_footer::{}
+'''
+
+// duplicate import type:
+invalid_schema::document::'''
+  schema_header::{
+    imports: [
+      { id: "schema/util/positive_int.isl", type: positive_int },
+      { id: "schema/util/positive_int.isl", type: positive_int },
+    ],
+  }
+  schema_footer::{}
+'''
+

--- a/data/test/schema/invalid.isl
+++ b/data/test/schema/invalid.isl
@@ -1,7 +1,10 @@
-invalid_schema::(
+// missing schema_footer:
+invalid_schema::document::'''
   schema_header::{}
-)
+'''
 
-invalid_schema::(
+// missing schema_header:
+invalid_schema::document::'''
   schema_footer::{}
-)
+'''
+

--- a/data/test/schema/open_content.isl
+++ b/data/test/schema/open_content.isl
@@ -1,0 +1,29 @@
+// verify that open content in a schema is ignored
+schema_header::{
+  open: content,
+}
+not_a_type::{}
+5
+type::{
+  name: short_string,
+  codepoint_length: range::[1, 5],
+}
+hello
+also_not_a_type::{}
+schema_footer::{
+  open: content,
+}
+
+valid::{
+  short_string: [
+    "a",
+    "abcde",
+  ],
+}
+invalid::{
+  short_string: [
+    "",
+    "abcdef",
+  ],
+}
+

--- a/data/test/schema/util/positive_int.isl
+++ b/data/test/schema/util/positive_int.isl
@@ -1,11 +1,9 @@
 schema_header::{}
-
 type::{
   name: positive_int,
   type: int,
   valid_values: range::[1, max]
 }
-
 schema_footer::{}
 
 valid::{


### PR DESCRIPTION
Resolves #1 

Tests include:
* importing an entire schema
* importing a specific type from a schema
* importing a specific type from a schema using an alias
* verifying that open content in ISL is ignored
* misc. invalid schema tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
