### PR TITLE
adds explicit return types for improved readability of public APIs

### DIFF
--- a/src/software/amazon/ionschema/Type.kt
+++ b/src/software/amazon/ionschema/Type.kt
@@ -19,14 +19,14 @@ interface Type {
      * If the specified value violates one or more of this type's constraints,
      * returns `false`, otherwise `true`.
      */
-    fun isValid(value: IonValue) = validate(this, value, true).isValid()
+    fun isValid(value: IonValue): Boolean = validate(this, value, true).isValid()
 
     /**
      * Returns a Violations object indicating whether the specified value
      * is valid for this type, and if not, provides details as to which
      * constraints were violated.
      */
-    fun validate(value: IonValue) = validate(this, value, false)
+    fun validate(value: IonValue): Violations = validate(this, value, false)
 
     private fun validate(type: Type, value: IonValue, shortCircuit: Boolean): Violations {
         val violations = Violations(

--- a/src/software/amazon/ionschema/Violations.kt
+++ b/src/software/amazon/ionschema/Violations.kt
@@ -32,7 +32,7 @@ open class Violations internal constructor (
     /**
      * Returns `true` if no violations were found; otherwise `false`.
      */
-    fun isValid() = violations.isEmpty() && children.isEmpty()
+    fun isValid(): Boolean = violations.isEmpty() && children.isEmpty()
 
     internal fun add(violation: Violation): Boolean {
         (violation as Violations).shortCircuit = shortCircuit


### PR DESCRIPTION
Resolves #92 

As recommended in #80;  all other public elements already declare their type explicitly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
