### PR TITLE
adds fun Schema.plusType(String | IonStruct): Schema

### DIFF
--- a/src/software/amazon/ionschema/Schema.kt
+++ b/src/software/amazon/ionschema/Schema.kt
@@ -8,6 +8,14 @@ import software.amazon.ion.IonStruct
  * Each type may refer to other types within the same schema,
  * or types imported into this schema from other schemas.
  * To instantiate a Schema, see [IonSchemaSystem].
+ *
+ * Classes that implement this interface are expected to be
+ * immutable.  This avoids surprising behavior, for instance:
+ * if a particular type in a schema were allowed to be replaced,
+ * a value that was once valid for the type may no longer be valid.
+ * Instead, any methods that would mutate a Schema are expected
+ * to return a new Schema instance with the mutation applied
+ * (see [plusType] as an example of this).
  */
 interface Schema {
     /**
@@ -41,5 +49,23 @@ interface Schema {
      * @return the new type
      */
     fun newType(isl: IonStruct): Type
+
+    /**
+     * Constructs a new type using the type ISL provided as a String,
+     * and returns a new Schema instance containing all the types
+     * of this instance plus the new type.  Note that the new type
+     * in the returned instance will hide a type of the same name
+     * from this instance.
+     */
+    fun plusType(isl: String): Schema
+
+    /**
+     * Constructs a new type using the type ISL provided as an IonStruct.
+     * and returns a new Schema instance containing all the types
+     * of this instance plus the new type.  Note that the new type
+     * in the returned instance will hide a type of the same name
+     * from this instance.
+     */
+    fun plusType(isl: IonStruct): Schema
 }
 

--- a/src/software/amazon/ionschema/Schema.kt
+++ b/src/software/amazon/ionschema/Schema.kt
@@ -51,21 +51,11 @@ interface Schema {
     fun newType(isl: IonStruct): Type
 
     /**
-     * Constructs a new type using the type ISL provided as a String,
-     * and returns a new Schema instance containing all the types
-     * of this instance plus the new type.  Note that the new type
+     * Returns a new Schema instance containing all the types of this
+     * instance plus the provided type.  Note that the added type
      * in the returned instance will hide a type of the same name
      * from this instance.
      */
-    fun plusType(isl: String): Schema
-
-    /**
-     * Constructs a new type using the type ISL provided as an IonStruct.
-     * and returns a new Schema instance containing all the types
-     * of this instance plus the new type.  Note that the new type
-     * in the returned instance will hide a type of the same name
-     * from this instance.
-     */
-    fun plusType(isl: IonStruct): Schema
+    fun plusType(type: Type): Schema
 }
 

--- a/src/software/amazon/ionschema/internal/SchemaCore.kt
+++ b/src/software/amazon/ionschema/internal/SchemaCore.kt
@@ -46,8 +46,7 @@ internal class SchemaCore(
 
     override fun newType(isl: String) = throw UnsupportedOperationException()
     override fun newType(isl: IonStruct) = throw UnsupportedOperationException()
-    override fun plusType(isl: String) = throw UnsupportedOperationException()
-    override fun plusType(isl: IonStruct) = throw UnsupportedOperationException()
+    override fun plusType(type: Type) = throw UnsupportedOperationException()
 }
 
 private const val CORE_TYPES = """

--- a/src/software/amazon/ionschema/internal/SchemaCore.kt
+++ b/src/software/amazon/ionschema/internal/SchemaCore.kt
@@ -45,8 +45,9 @@ internal class SchemaCore(
     override fun getSchemaSystem() = schemaSystem
 
     override fun newType(isl: String) = throw UnsupportedOperationException()
-
     override fun newType(isl: IonStruct) = throw UnsupportedOperationException()
+    override fun plusType(isl: String) = throw UnsupportedOperationException()
+    override fun plusType(isl: IonStruct) = throw UnsupportedOperationException()
 }
 
 private const val CORE_TYPES = """

--- a/src/software/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/software/amazon/ionschema/internal/SchemaImpl.kt
@@ -5,25 +5,36 @@ import software.amazon.ion.IonString
 import software.amazon.ion.IonStruct
 import software.amazon.ion.IonSymbol
 import software.amazon.ion.IonValue
+import software.amazon.ionschema.EMPTY_ITERATOR
 import software.amazon.ionschema.InvalidSchemaException
-import software.amazon.ionschema.IonSchemaSystem
 import software.amazon.ionschema.Schema
 import software.amazon.ionschema.Type
 
 /**
  * Implementation of [Schema] for all user-provided ISL.
  */
-internal class SchemaImpl(
+internal class SchemaImpl internal constructor(
         private val schemaSystem: IonSchemaSystemImpl,
         private val schemaCore: SchemaCore,
-        schemaContent: Iterator<IonValue>
+        schemaContent: Iterator<IonValue>,
+        /*
+         * [types] is declared as a MutableMap in order to be populated DURING
+         * INITIALIZATION ONLY.  This enables type B to find it's already-loaded
+         * dependency type A.  After initialization, [types] is expected to
+         * be treated as immutable as required by the Schema interface.
+         */
+        private val types: MutableMap<String, Type> = mutableMapOf()
 ) : Schema {
 
-    private val types: Map<String, Type>
     private val deferredTypeReferences = mutableListOf<TypeReferenceDeferred>()
 
+    private constructor(
+            schemaSystem: IonSchemaSystemImpl,
+            schemaCore: SchemaCore,
+            types: MutableMap<String, Type>
+        ) : this(schemaSystem, schemaCore, EMPTY_ITERATOR, types)
+
     init {
-        types = mutableMapOf()
         var foundHeader = false
         var foundFooter = false
 
@@ -100,6 +111,16 @@ internal class SchemaImpl(
         val type = TypeImpl(isl, this)
         resolveDeferredTypeReferences()
         return type
+    }
+
+    override fun plusType(isl: String) = plusType(
+            schemaSystem.getIonSystem().singleValue(isl) as IonStruct)
+
+    override fun plusType(isl: IonStruct): Schema {
+        val newTypes = types.toMutableMap()
+        val newType = newType(isl)
+        newTypes[newType.name] = newType
+        return SchemaImpl(schemaSystem, schemaCore, newTypes)
     }
 
     override fun getSchemaSystem() = schemaSystem

--- a/src/software/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/software/amazon/ionschema/internal/SchemaImpl.kt
@@ -19,7 +19,7 @@ internal class SchemaImpl internal constructor(
         schemaContent: Iterator<IonValue>,
         /*
          * [types] is declared as a MutableMap in order to be populated DURING
-         * INITIALIZATION ONLY.  This enables type B to find it's already-loaded
+         * INITIALIZATION ONLY.  This enables type B to find its already-loaded
          * dependency type A.  After initialization, [types] is expected to
          * be treated as immutable as required by the Schema interface.
          */
@@ -113,13 +113,9 @@ internal class SchemaImpl internal constructor(
         return type
     }
 
-    override fun plusType(isl: String) = plusType(
-            schemaSystem.getIonSystem().singleValue(isl) as IonStruct)
-
-    override fun plusType(isl: IonStruct): Schema {
+    override fun plusType(type: Type): Schema {
         val newTypes = types.toMutableMap()
-        val newType = newType(isl)
-        newTypes[newType.name] = newType
+        newTypes[type.name] = type
         return SchemaImpl(schemaSystem, schemaCore, newTypes)
     }
 

--- a/test/software/amazon/ionschema/SchemaTest.kt
+++ b/test/software/amazon/ionschema/SchemaTest.kt
@@ -76,57 +76,36 @@ class SchemaTest {
     }
 
     @Test
-    fun plusType_string() {
-        plusType(arrayOf("type::{ name: A, codepoint_length: 3 }",
-                         "type::{ name: A, codepoint_length: 5 }",
-                         "type::{ name: B }"),
-                 null)
-    }
-
-    @Test
-    fun plusType_struct() {
-        plusType(null,
-                 arrayOf(structOf("type::{ name: A, codepoint_length: 3 }"),
-                         structOf("type::{ name: A, codepoint_length: 5 }"),
-                         structOf("type::{ name: B }")))
-    }
-
-    private fun structOf(s: String) = ION.singleValue(s) as IonStruct
-
-    private fun plusType(strings: Array<String>?, structs: Array<IonStruct>?) {
+    fun plusType() {
         val schema = iss.newSchema()
-        val schema1 = when {
-            strings != null -> schema.plusType(strings[0])
-            structs != null -> schema.plusType(structs[0])
-            else -> throw UnsupportedOperationException()
-        }
-        val schema2 = when {
-            strings != null -> schema1.plusType(strings[1])
-            structs != null -> schema1.plusType(structs[1])
-            else -> throw UnsupportedOperationException()
-        }
+
+        val type1 = schema.newType("type::{ name: A, codepoint_length: 3 }")
+        val schema1 = schema.plusType(type1)
+
+        val type2 = schema.newType("type::{ name: A, codepoint_length: 5 }")
+        val schema2 = schema1.plusType(type2)
 
         // verify the type remains unchanged in the original schema
-        val type3 = schema1.getType("A")!!
-        assertFalse(type3.isValid(ION.singleValue("ab")))
-        assertTrue (type3.isValid(ION.singleValue("abc")))
-        assertFalse(type3.isValid(ION.singleValue("abcd")))
+        val typeA1 = schema1.getType("A")!!
+        assertFalse(typeA1.isValid(ION.singleValue("ab")))
+        assertTrue (typeA1.isValid(ION.singleValue("abc")))
+        assertFalse(typeA1.isValid(ION.singleValue("abcd")))
 
         // verify the type reflects new behavior when retrieved from the newer schema instance
-        val type5 = schema2.getType("A")!!
-        assertFalse(type5.isValid(ION.singleValue("abcd")))
-        assertTrue (type5.isValid(ION.singleValue("abcde")))
-        assertFalse(type5.isValid(ION.singleValue("abcdef")))
+        val typeA2 = schema2.getType("A")!!
+        assertFalse(typeA2.isValid(ION.singleValue("abcd")))
+        assertTrue (typeA2.isValid(ION.singleValue("abcde")))
+        assertFalse(typeA2.isValid(ION.singleValue("abcdef")))
 
         // verify a new type 'B' isn't available from the earlier schema instances
-        val schema3 = when {
-            strings != null -> schema1.plusType(strings[2])
-            structs != null -> schema1.plusType(structs[2])
-            else -> throw UnsupportedOperationException()
-        }
+        val type3 = schema.newType("type::{ name: B }")
+        val schema3 = schema2.plusType(type3)
         assertNull   (schema1.getType("B"))
         assertNull   (schema2.getType("B"))
         assertNotNull(schema3.getType("B"))
+
+        // verify the original schema remains empty
+        assertEquals(0, schema.getTypes().asSequence().count())
     }
 }
 


### PR DESCRIPTION
Resolves #73 

Following the pattern of PCollection's `PMap.plus` and Kotlin's `Map.plus`, adds `Schema.plusType()` methods while maintaining Schema immutability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
