### PR TITLE
fixes 'not: {}' test and removes it from the blacklist

### DIFF
--- a/data/test/constraints/not/empty_type.isl
+++ b/data/test/constraints/not/empty_type.isl
@@ -1,10 +1,34 @@
 type::{
   not: {},     // equivalent to not: { type: any }
+  type: $any,  // override the default "type: any" constraint, otherwise any null value will be invalid
 }
 valid::[
   null,
+  null.blob,
+  null.bool,
+  null.clob,
+  null.decimal,
+  null.float,
+  null.int,
+  null.list,
+  null.sexp,
+  null.string,
+  null.struct,
+  null.symbol,
+  null.timestamp,
 ]
 invalid::[
+  true,
   5,
+  5e0,
+  5d0,
+  2019-01-01T,
+  symbol,
+  "string",
+  {{ "clob" }},
+  {{aGVsbG8=}},
+  [],
+  (),
+  {},
 ]
 

--- a/test/software/amazon/ionschema/IonSchemaTestRunner.kt
+++ b/test/software/amazon/ionschema/IonSchemaTestRunner.kt
@@ -34,9 +34,7 @@ class IonSchemaTestRunner(
 
     private val schemaCore = SchemaCore(schemaSystem)
 
-    private val blacklist = setOf(
-            "data/test/constraints/not/empty_type.isl"
-    )
+    private val blacklist = setOf("")
 
     private val specialFieldNames = setOf("fields", "element")
 


### PR DESCRIPTION
Resolves #71 

Test had been moved to data/test/constraints/not/empty_type.isl

Test required the default "type: any" behavior to be overridden in order to verify that "not: {}" (aka "not: { type: any }") is valid for null values.  That's why it was failing prior to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
