### PR TITLE
upgrades to s.a.i.ion-java:1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-  api "software.amazon.ion:ion-java:[1.3,)"
+  api "software.amazon.ion:ion-java:[1.4,)"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }

--- a/src/software/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
+++ b/src/software/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
@@ -90,7 +90,7 @@ internal enum class IonTimestampPrecision (val id: Int) {
                     Timestamp.Precision.MONTH -> month.id
                     Timestamp.Precision.DAY -> day.id
                     Timestamp.Precision.MINUTE -> minute.id
-                    Timestamp.Precision.SECOND -> ion.timestampValue().decimalSecond.scale()
+                    Timestamp.Precision.SECOND, Timestamp.Precision.FRACTION -> ion.timestampValue().decimalSecond.scale()
                     null -> throw NullPointerException()
                 }
     }


### PR DESCRIPTION
ion-java 1.4.0 introduced a new `Timestamp.Precision` which breaks a `when` clause in `IonTimestampPrecision` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
