### PR TITLE
updates the ordered_elements constraint to follow multiple solution paths

### DIFF
--- a/data/test/constraints/occurs/validation_ordered_elements.isl
+++ b/data/test/constraints/occurs/validation_ordered_elements.isl
@@ -14,17 +14,6 @@ test_validation::{
         ],
       },
       code: ordered_elements_mismatch,
-      children: [
-        {
-          index: 1,
-          violations: [
-            {
-              constraint: { occurs: range::[2, 4] },
-              code: occurs_mismatch,
-            },
-          ],
-        },
-      ],
     },
   ],
 }

--- a/data/test/constraints/occurs/validation_ordered_elements_optional.isl
+++ b/data/test/constraints/occurs/validation_ordered_elements_optional.isl
@@ -18,27 +18,6 @@ test_validation::{
         ],
       },
       code: ordered_elements_mismatch,
-      children: [
-        {
-          index: 1,
-          value: hello,
-          violations: [
-            {
-              constraint: { type: int },
-              code: type_mismatch,
-            },
-          ],
-        },
-        {
-          index: 2,
-          violations: [
-            {
-              constraint: { occurs: range::[1, 3] },
-              code: occurs_mismatch,
-            },
-          ],
-        },
-      ],
     },
   ],
 }
@@ -54,11 +33,7 @@ test_validation::{
           { type: string, occurs: range::[1, 3] },
         ],
       },
-      code: unexpected_content,
-      children: [
-        { index: 6, value: "4" },
-        { index: 7, value: "5" },
-      ],
+      code: ordered_elements_mismatch,
     },
   ],
 }

--- a/data/test/constraints/ordered_elements/occurs_3.isl
+++ b/data/test/constraints/ordered_elements/occurs_3.isl
@@ -1,0 +1,19 @@
+type::{
+  ordered_elements: [
+    { type: int, occurs: optional },
+    int,
+    symbol,
+  ],
+}
+
+valid::[
+  [1, a],
+  [1, 2, a],
+]
+
+invalid::[
+  [1],
+  [a],
+  [1, 2, 3, a],
+]
+

--- a/data/test/constraints/ordered_elements/validation_core_types.isl
+++ b/data/test/constraints/ordered_elements/validation_core_types.isl
@@ -14,38 +14,6 @@ test_validation::{
     {
       constraint: { ordered_elements: [int, decimal, string] },
       code: ordered_elements_mismatch,
-      children: [
-        {
-          index: 0,
-          value: true,
-          violations: [
-            {
-              constraint: { type: int },
-              code: type_mismatch,
-            },
-          ],
-        },
-        {
-          index: 1,
-          value: 5,
-          violations: [
-            {
-              constraint: { type: decimal },
-              code: type_mismatch,
-            },
-          ],
-        },
-        {
-          index: 2,
-          value: hello,
-          violations: [
-            {
-              constraint: { type: string },
-              code: type_mismatch,
-            },
-          ],
-        },
-      ],
     },
   ],
 }
@@ -57,11 +25,7 @@ test_validation::{
   violations: [
     {
       constraint: { ordered_elements: [ int, decimal, string ] },
-      code: unexpected_content,
-      children: [
-        { index: 3, value: extra_content },
-        { index: 4, value: more_extra_content },
-      ],
+      code: ordered_elements_mismatch,
     },
   ],
 }

--- a/data/test/constraints/ordered_elements/validation_inlined_types.isl
+++ b/data/test/constraints/ordered_elements/validation_inlined_types.isl
@@ -28,30 +28,6 @@ test_validation::{
         ],
       },
       code: ordered_elements_mismatch,
-      children: [
-        {
-          index: 1,
-          value: {},
-          violations: [
-            { constraint: { type: int }, code: type_mismatch },
-            { constraint: { type: decimal }, code: type_mismatch },
-            { constraint: { type: float }, code: type_mismatch },
-            { constraint: { type: symbol }, code: type_mismatch },
-          ],
-        },
-        {
-          index: 2,
-          violations: [
-            { constraint: { occurs: required }, code: occurs_mismatch },
-          ],
-        },
-        {
-          index: 2,
-          violations: [
-            { constraint: { occurs: required }, code: occurs_mismatch },
-          ],
-        },
-      ],
     },
   ],
 }

--- a/src/software/amazon/ionschema/internal/constraint/OrderedElements.kt
+++ b/src/software/amazon/ionschema/internal/constraint/OrderedElements.kt
@@ -3,10 +3,10 @@ package software.amazon.ionschema.internal.constraint
 import software.amazon.ion.*
 import software.amazon.ionschema.InvalidSchemaException
 import software.amazon.ionschema.Schema
-import software.amazon.ionschema.internal.constraint.Occurs.Companion.REQUIRED
-import software.amazon.ionschema.ViolationChild
 import software.amazon.ionschema.Violations
 import software.amazon.ionschema.Violation
+import software.amazon.ionschema.internal.TypeReference
+import software.amazon.ionschema.internal.util.IntRange
 
 /**
  * Implements the ordered_element constraint.
@@ -18,95 +18,34 @@ internal class OrderedElements(
         private val schema: Schema
 ) : ConstraintBase(ion) {
 
+    private val stateMachine: StateMachine
+
     init {
         if (ion !is IonList || ion.isNullValue) {
             throw InvalidSchemaException("Invalid ordered_elements constraint: $ion")
-        } else {
-            ion.map { Occurs(it, schema, REQUIRED) }
         }
+
+        val stateMachineBuilder = StateMachineBuilder()
+
+        var state: State? = null
+        ion.forEachIndexed { idx, it ->
+            val occursRange = IntRange.toIntRange((it as? IonStruct)?.get("occurs")) ?: IntRange.REQUIRED
+            val newState = State(occursRange, isFinal = idx == ion.size - 1)
+            val typeResolver = TypeReference.create(it, schema)
+            stateMachineBuilder.addTransition(state, EventSchemaType(typeResolver), newState)
+            state = newState
+        }
+
+        stateMachine = stateMachineBuilder.build()
     }
 
-    // TBD this impl does not backtrack
     override fun validate(value: IonValue, issues: Violations) {
-        validateAs<IonSequence>(value, issues) validateAs@{ v ->
-            val types = (ion as IonList).map {
-                Occurs(it, schema, REQUIRED)
-            }.toList()
-
-            var typeIdx = 0
-            val elements = v
-            var elementIdx = 0
-
-            val violation = Violation(ion, "ordered_elements_mismatch",
-                    "one or more ordered elements don't match specification")
-
-            var elementValidation = newViolationChild(elementIdx, elements)
-
-            while (true) {
-                if (typeIdx == types.size) {
-                    // we've exhausted the types, have we exhausted the elements?
-                    if (elementIdx != elements.size) {
-                        val newViolation = Violation(ion, "unexpected_content", "unexpected content for ordered elements")
-                        for (i in elementIdx..(elements.size - 1)) {
-                            newViolation.add(ViolationChild(index = i, value = elements[i]))
-                        }
-                        issues.add(newViolation)
-                    }
-                    if (!violation.isValid()) {
-                        issues.add(violation)
-                    }
-                    return@validateAs   // either way, we've gone as far as we can
-                }
-
-                val type = types[typeIdx]
-
-                if (elementIdx == elements.size) {
-                    // we've exhausted the elements, did we meet the type's "occurs" requirements?
-                    if (!type.isValidCountWithinRange()) {
-                        elementValidation = newViolationChild(elementIdx, elements)
-                        elementValidation.add(
-                                Violation(type.occursIon,
-                                        "occurs_mismatch",
-                                        "expected %s occurrences, found %s".format(type.range, type.validCount)))
-
-                        violation.add(elementValidation)
-                    }
-
-                    // keep going...there may be other types that expect to be matched
-                    typeIdx++
-
-                } else {
-                    val checkpoint = elementValidation.checkpoint()
-                    type.validate(elements[elementIdx], elementValidation)
-                    if (checkpoint.isValid()) {
-                        if (!type.canConsumeMore()) {
-                            typeIdx++
-                        }
-                        elementIdx++
-                        elementValidation = newViolationChild(elementIdx, elements)
-                    } else {
-                        if (!type.canConsumeMore()) {
-                            typeIdx++
-                            if (!type.range.contains(0)) {
-                                violation.add(elementValidation)
-                                elementIdx++
-                                elementValidation = newViolationChild(elementIdx, elements)
-                            }
-                        } else if (type.attemptsSatisfyOccurrences()) {
-                            typeIdx++
-                            type.validateValidCount(issues)
-                        }
-                    }
-                }
+        validateAs<IonSequence>(value, issues) { v ->
+            if (!stateMachine.matches(v.iterator())) {
+                issues.add(Violation(ion, "ordered_elements_mismatch",
+                        "one or more ordered elements don't match specification"))
             }
         }
     }
-
-    private fun newViolationChild(idx: Int, elements: IonSequence) =
-        if (idx < elements.size) {
-            ViolationChild(index = idx, value = elements[idx])
-        } else {
-            ViolationChild(index = idx)
-        }
 }
 

--- a/src/software/amazon/ionschema/internal/constraint/StateMachine.kt
+++ b/src/software/amazon/ionschema/internal/constraint/StateMachine.kt
@@ -1,22 +1,45 @@
 package software.amazon.ionschema.internal.constraint
 
 import software.amazon.ion.IonValue
+import software.amazon.ionschema.internal.util.IntRange
+
+private val OPEN_CONTENT_FLAG = Any()
+private val DEBUG = false
 
 /**
  * Builder that provides a simple API for constructing a [StateMachine].
  */
 internal class StateMachineBuilder {
-    private val states = StateSet()
-    val initialState = State()
+    private val initialState = State(IntRange.OPTIONAL)
+    private val states = mutableSetOf(initialState)
+    private var openContent: Any? = null
 
-    fun addTransition(fromState: State, event: Event, toState: State) {
-        if (!states.contains(fromState)) {
-            states.add(fromState)
-        }
-        fromState.transitions[event] = toState
+    fun withOpenContent(): StateMachineBuilder {
+        openContent = OPEN_CONTENT_FLAG
+        return this
     }
 
-    fun build() = StateMachine(states, initialState)
+    fun addTransition(fromState: State?, event: Event, toState: State): StateMachineBuilder {
+        val initialOrFromState = fromState ?: initialState
+        if (!states.contains(initialOrFromState)) {
+            states.add(initialOrFromState)
+        }
+        initialOrFromState.addTransition(event, toState)
+
+        if (!states.contains(toState)) {
+            states.add(toState)
+        }
+
+        // for states that may recur, auto-add a transition back to itself
+        if (toState.isRecurring()) {
+            toState.addTransition(event, toState)
+        }
+        return this
+    }
+
+    fun build(): StateMachine {
+        return StateMachine(states, initialState, openContent)
+    }
 }
 
 /**
@@ -29,117 +52,188 @@ internal class StateMachineBuilder {
  *      http://doi.acm.org/10.1145/363347.363387
  */
 internal class StateMachine(
-        private val states: StateSet,
-        private val initialState: State
+        private val states: Set<State>,
+        private val initialState: State,
+        private val openContent: Any?
 ) {
     fun matches(iter: Iterator<IonValue>): Boolean {
-        var states = addNextStates(StateSet(initialState), initialState, Event.NOOP)
+        if (DEBUG) { println(this) }
 
-        iter.forEach {
-            val newStates = StateSet()
+        val stateSet = StateSet(initialState, openContent)
+        initialState.transitionToOptionalStates(stateSet)
+        stateSet.applyVisits()
 
-            states.forEach { state ->
-                addNextStates(newStates, state, Event(it))
-                addNextStates(newStates, state, Event.ANY)
+        if (DEBUG) { debug(stateSet) }
+        iter.forEach { ion ->
+            stateSet.forEach { state, _ ->
+                state.transition(EventIonValue(ion), stateSet)
             }
-
-            HashSet(newStates).forEach { newState ->
-                addNextStates(newStates, newState, Event.NOOP)
-            }
-
-            states = newStates
-
-            // short-circuit if we've arrived at a final state
-            if (states.hasFinalState()) {
-                return true
-            }
+            stateSet.applyVisits()
+            if (DEBUG) { debug(stateSet, ion) }
         }
 
-        return states.hasFinalState()
+        return stateSet.hasFinalState
     }
 
-    private fun addNextStates(states: StateSet, fromState: State, event: Event): StateSet {
-        fromState.transitions.let {
-            val toState = fromState.transitions[event]
-            toState?.let {
-                states.add(toState)
-                if (event == Event.NOOP) {
-                    // recursively add any no-op paths
-                    addNextStates(states, toState, Event.NOOP)
-                }
-            }
+    private fun debug(stateSet: StateSet, value: IonValue? = null) {
+        print(if (stateSet.hasFinalState) { "F" } else { "." })
+        if (value == null) {
+            print(" <init> --> ")
+        } else {
+            print(" $value --> ")
         }
-        return states
+        stateSet.asSequence()
+            .sortedBy { it.key.stateId }
+            .forEach {
+                print("${it.key.stateId}:${stateSet.visitCount(it.key)}")
+                print(" ")
+            }
+        println()
     }
 
     override fun toString(): String {
         val sb = StringBuilder()
-        states.forEach {
-            sb.appendln(it)
-            it.transitions.forEach {
-                sb.appendln("  ${it.key} --> ${it.value}")
+        states.asSequence()
+            .sortedBy { it.stateId }
+            .forEach { sb.append(it) }
+        return sb.toString()
+    }
+
+    // encapsulates state tracking logic, plus intelligent tracking of "are we in a valid end state"
+    internal inner class StateSet constructor(
+            initialState: State,
+            private val openContent: Any? = null
+    ) {
+        private val newStates = mutableMapOf(initialState to 0)
+
+        internal var hasFinalState = calcHasFinalState()
+        private var prevStates = mutableMapOf<State, Int>()
+        private val newStateVisits = mutableMapOf<State, Int>()
+
+        fun visit(state: State, preemptiveVisit: Boolean = false) {
+            newStateVisits[state] = when {
+                !preemptiveVisit -> 1
+                else -> newStateVisits[state] ?: 0
             }
+        }
+
+        fun visitCount(state: State) = prevStates[state] ?: 0
+
+        fun applyVisits() {
+            newStateVisits.forEach { state, visits ->
+                newStates[state] = (prevStates[state] ?: 0) + visits
+            }
+            newStateVisits.clear()
+            hasFinalState = calcHasFinalState()
+
+            prevStates = newStates.toMutableMap()
+            openContent ?: newStates.clear()
+        }
+
+        private fun calcHasFinalState() = when {
+            // special case where there is a single state (the initialState),
+            // and newStates has exactly one state (which must also be the initialState)
+            this@StateMachine.states.size == 1 && newStates.size == 1 -> true
+            else -> {
+                newStates.asSequence()
+                        .takeWhile { stateVisit ->
+                            !stateVisit.key.isFinal(stateVisit.value)
+                        }
+                        .count() != newStates.size
+            }
+        }
+
+        fun asSequence(): Sequence<Map.Entry<State, Int>> = prevStates.asSequence()
+        fun forEach(action: (State, Int) -> Unit) = prevStates.forEach(action)
+    }
+}
+
+private var stateCnt = 0
+
+// represents a state in the state machine model
+internal class State private constructor(
+        private val occurs: IntRange,
+        private val type: StateType,
+        private val transitions: MutableMap<Event,State> = mutableMapOf()
+) {
+    internal val stateId = "S$stateCnt"
+    init {
+        stateCnt += 1
+    }
+
+    constructor(occurs: IntRange, isFinal: Boolean = false)
+            : this(occurs, if (isFinal) { StateType.FINAL } else { StateType.INTERMEDIATE })
+
+    internal fun addTransition(event: Event, toState: State) {
+        transitions[event] = toState
+    }
+
+    internal fun transition(event: Event? = null, stateSet: StateMachine.StateSet) {
+        val value = (event as? EventIonValue)?.ion
+        val visitCount = stateSet.visitCount(this)
+        transitions.forEach { eventCandidate, toState ->
+            when {
+                   (toState != this && occurs.lower <= visitCount)       // allow proceeding to the next state if we've reached minOccurs
+                || (toState == this && occurs.upper >  visitCount) -> {  // allow repeat of current state if we haven't yet reached maxOccurs
+
+                    if (eventCandidate.matches(value)) {
+                        stateSet.visit(toState)
+                        if (toState.occurs.lower <= stateSet.visitCount(toState) + 1) {
+                            toState.transitionToOptionalStates(stateSet)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal fun transitionToOptionalStates(stateSet: StateMachine.StateSet): List<State> =
+            transitions.values
+                    .filterNot { it == this }
+                    .filter { it.occurs.contains(0) }
+                    .onEach {
+                        stateSet.visit(it, preemptiveVisit = true)
+                        it.transitionToOptionalStates(stateSet)
+                    }
+
+    internal fun isFinal(visits: Int) =
+            type == StateType.FINAL
+                    && occurs.contains(visits)
+
+    internal fun isRecurring() = occurs.upper > 1
+
+    override fun toString(): String {
+        val sb = StringBuilder("$stateId:$occurs")
+        if (type == StateType.FINAL) {
+            sb.append(" <final>")
+        }
+        sb.appendln()
+        transitions.forEach {
+            sb.appendln("  ${it.key} --> ${it.value.stateId}")
         }
         return sb.toString()
     }
-}
 
-internal class StateSet private constructor(
-        private val delegate: MutableSet<State>
-) : MutableSet<State> by delegate {
-
-    constructor(vararg elements: State) : this(mutableSetOf<State>(*elements))
-
-    private var hasFinalState = false
-
-    override fun add(element: State): Boolean {
-        if (element.isFinal()) {
-            hasFinalState = true
-        }
-        return delegate.add(element)
-    }
-
-    fun hasFinalState() = hasFinalState
-}
-
-internal class State private constructor (
-        private val stateType: StateType,
-        internal val transitions: MutableMap<Event,State> = mutableMapOf()
-) {
     private enum class StateType {
         INTERMEDIATE,
         FINAL,
     }
-
-    constructor(isFinal: Boolean = false)
-            : this(if (isFinal) { StateType.FINAL } else { StateType.INTERMEDIATE })
-
-    fun isFinal() = stateType == StateType.FINAL
-
-    override fun toString() = if (stateType == StateType.INTERMEDIATE) {
-            "s${hashCode()}"
-        } else {
-            "s${hashCode()}($stateType)"
-        }
 }
 
-internal data class Event private constructor (
-        private val eventType: EventType,
-        private val ion: IonValue? = null
-) {
-    private enum class EventType {
-        ANY,
-        NOOP,
-        IONVALUE,
-    }
+// base class for all event types
+abstract class Event {
+    abstract fun matches(value: IonValue?): Boolean
+}
 
-    constructor(ion: IonValue) : this(EventType.IONVALUE, ion)
+// represents an event that corresponds to a specific Ion value
+internal class EventIonValue(internal val ion: IonValue) : Event() {
+    override fun matches(value: IonValue?) = ion == value
+    override fun toString() = "$ion"
+}
 
-    companion object {
-        val ANY = Event(EventType.ANY)
-        val NOOP = Event(EventType.NOOP)
-    }
-
-    override fun toString() = if (eventType == EventType.IONVALUE) { "$ion" } else { "$eventType" }
+// represents an event that corresponds to an Ion Schema Type
+internal data class EventSchemaType(private val typeResolver: () -> software.amazon.ionschema.Type) : Event() {
+    override fun matches(value: IonValue?) = if (value == null) { false } else { typeResolver().isValid(value) }
+    override fun toString() = "type: ${typeResolver().name}"
 }
 

--- a/src/software/amazon/ionschema/internal/util/IntRange.kt
+++ b/src/software/amazon/ionschema/internal/util/IntRange.kt
@@ -1,0 +1,126 @@
+package software.amazon.ionschema.internal.util
+
+import software.amazon.ion.IonInt
+import software.amazon.ion.IonList
+import software.amazon.ion.IonSymbol
+import software.amazon.ion.IonValue
+import software.amazon.ion.system.IonSystemBuilder
+import software.amazon.ionschema.InvalidSchemaException
+import java.math.BigInteger
+
+internal interface IntRange {
+    companion object {
+        private val ION = IonSystemBuilder.standard().build()
+
+        internal val OPTIONAL: IntRange = toIntRange(ION.singleValue("optional"))!!
+        internal val REQUIRED: IntRange = toIntRange(ION.singleValue("required"))!!
+
+        fun toIntRange(ion: IonValue?) = when (ion) {
+            is IonInt -> IntRangeForIonInt(ion)
+            is IonList -> IntRangeForIonList(ion)
+            is IonSymbol -> IntRangeForIonSymbol(ion)
+            null -> null
+            else -> throw InvalidSchemaException("Unable to parse $ion as an int range")
+        }
+    }
+
+    val lower: IntRangeBoundary
+    val upper: IntRangeBoundary
+
+    fun contains(value: Int) = contains(BigInteger.valueOf(value.toLong()))
+    fun contains(value: BigInteger): Boolean
+}
+
+private class IntRangeForIonList(
+        private val ion: IonList
+) : IntRange {
+
+    companion object {
+        private val MIN = IntRangeBoundaryConstant(-1)
+        private val MAX = IntRangeBoundaryConstant(1)
+    }
+
+    init {
+        checkRange(ion)
+    }
+
+    override val lower = when {
+        isRangeMin(ion[0]) -> MIN
+        ion[0] is IonInt -> IntRangeLowerBoundary(ion[0] as IonInt)
+        else -> throw InvalidSchemaException("Unable to parse lower bound of $ion")
+    }
+
+    override val upper = when {
+        isRangeMax(ion[1]) -> MAX
+        ion[1] is IonInt -> IntRangeUpperBoundary(ion[1] as IonInt)
+        else -> throw InvalidSchemaException("Unable to parse upper bound of $ion")
+    }
+
+    override fun contains(value: BigInteger) = lower <= value && upper >= value
+    override fun toString() = ion.toString()
+}
+
+private class IntRangeForIonInt(
+        private val ion: IonInt
+) : IntRange {
+
+    private val theValue = ion.bigIntegerValue()
+
+    private val boundary = object : IntRangeBoundary {
+        override fun compareTo(other: BigInteger) = theValue.compareTo(other)
+    }
+
+    override val lower = boundary
+    override val upper = boundary
+    override fun contains(value: BigInteger) = theValue == value
+    override fun toString() = ion.toString()
+}
+
+private class IntRangeForIonSymbol private constructor(
+        private val ion: IonSymbol,
+        delegate: IntRange
+) : IntRange by delegate {
+
+    internal constructor(ion: IonSymbol)
+            : this(ion, when (ion.stringValue()) {
+                            "optional" -> IntRangeForIonList(ion.system.singleValue("range::[0, 1]") as IonList)
+                            "required" -> IntRangeForIonInt(ion.system.singleValue("1") as IonInt)
+                            else -> throw InvalidSchemaException("Unable to parse $ion as an int range")
+                        })
+
+    override fun toString() = ion.toString()
+}
+
+
+internal interface IntRangeBoundary {
+    operator fun compareTo(other: Int) = compareTo(BigInteger.valueOf(other.toLong()))
+    operator fun compareTo(other: BigInteger): Int
+}
+
+private abstract class IntRangeBoundaryBase(
+        ion: IonInt,
+        compareToResponseWhenExclusiveAndEqual: Int
+) : IntRangeBoundary {
+
+    private val value = ion.bigIntegerValue()
+
+    private val compareToResponseWhenEqual = when (RangeBoundaryType.forIon(ion)) {
+        RangeBoundaryType.INCLUSIVE -> 0
+        RangeBoundaryType.EXCLUSIVE -> compareToResponseWhenExclusiveAndEqual
+    }
+
+    override operator fun compareTo(other: BigInteger): Int {
+        val compareResult = value.compareTo(other)
+        return when (compareResult) {
+            0 -> compareToResponseWhenEqual
+            else -> compareResult
+        }
+    }
+}
+
+private class IntRangeLowerBoundary(ion: IonInt) : IntRangeBoundaryBase(ion, -1)
+private class IntRangeUpperBoundary(ion: IonInt) : IntRangeBoundaryBase(ion,  1)
+private class IntRangeBoundaryConstant(private val compareResult: Int) : IntRangeBoundary {
+    override operator fun compareTo(other: BigInteger) = compareResult
+}
+


### PR DESCRIPTION
via an enhanced StateMachine implementation;  updates the annotations constraint accordingly

Addresses the ordered_elements backtracking TBD called out pull request #84.  Resolves #75 

Note that some validation details have been dropped as it's not clear how to represent such details when the state machine has followed multiple, parallel paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
