### PR TITLE
fixes javadocJar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ task sourcesJar(type: Jar) {
   classifier = "sources"
 }
 task javadocJar(type: Jar) {
-  from javadoc
+  from dokka
   classifier = "javadoc"
 }
 publishing {
@@ -104,4 +104,3 @@ publishing {
 signing {
   sign publishing.publications.maven
 }
-


### PR DESCRIPTION
Koltin javadoc is generated by the dokka task and not the javadoc taks
so the javadocJar task that generates the javadoc artifact has to depend
on dokka

Tested with `./gradlew publishToMavenLocal` and inspecting the generated javadoc jar

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
