### PR TITLE
adds propagation of type aliases when importing a schema (#115)

### DIFF
--- a/data/test/schema/import/import_schema_with_aliased_type.isl
+++ b/data/test/schema/import/import_schema_with_aliased_type.isl
@@ -1,0 +1,33 @@
+// verifies an imported schema's type aliases are propagated correctly
+schema_header::{
+  imports: [
+    { id: "schema/import/import_type_by_alias.isl" },
+  ],
+}
+type::{
+  name: import_schema_with_aliased_type_test,
+  ordered_elements: [
+    positive_int_1,
+    positive_int_2,
+  ],
+}
+schema_footer::{
+}
+
+valid::{
+  import_type_by_alias_test: [
+    [1, 2],
+    (1 2),
+    document::"1 2",
+  ],
+}
+
+invalid::{
+  import_type_by_alias_test: [
+    [0, 0],
+    (-1 -1),
+    document::"0 0",
+    document::"1 hi",
+  ],
+}
+

--- a/data/test/schema/import/import_schema_with_aliased_type_invalid.isl
+++ b/data/test/schema/import/import_schema_with_aliased_type_invalid.isl
@@ -1,0 +1,13 @@
+// type 'positive_int' should not be recognized in this schema:
+invalid_schema::document::'''
+  schema_header::{
+    imports: [
+      { id: "schema/import/import_type_by_alias.isl" },
+    ],
+  }
+  type::{
+    name: import_schema_with_aliased_type_test,
+    type: positive_int,
+  }
+  schema_footer::{}
+'''

--- a/src/com/amazon/ionschema/internal/TypeAliased.kt
+++ b/src/com/amazon/ionschema/internal/TypeAliased.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ionschema.internal.constraint.ConstraintBase
+
+/**
+ * Implementation of [Type] representing a type imported with an alias.
+ */
+internal class TypeAliased(
+        ion: IonSymbol,
+        internal val type: TypeInternal
+) : TypeInternal by type, ConstraintBase(ion) {
+
+    override val name = ion.stringValue()
+}

--- a/test/com/amazon/ionschema/ISLforISLTestRunner.kt
+++ b/test/com/amazon/ionschema/ISLforISLTestRunner.kt
@@ -38,6 +38,7 @@ class ISLforISLTestRunner(
             .build()
 
     private val blacklist = setOf(
+            "data/test/schema/import/import_schema_with_aliased_type_invalid.isl",
             "data/test/schema/import/import_type_unknown.isl",
             "data/test/schema/import/invalid_duplicate_import.isl",
             "data/test/schema/import/invalid_duplicate_import_type.isl",


### PR DESCRIPTION
Resolves #115 

The import_schema_with_aliased_type_invalid.isl test is added to ISLforISLTestRunner's skip list because that test runner can only recognize invalid ISL -- it can't recognize that the `positive_int` type should not be available (which is why IonSchemaTestRunner recognizes it as invalid when the schema is loaded).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
