### PR TITLE
Improve performance of Occurs constraint

### DIFF
--- a/src/com/amazon/ionschema/internal/constraint/Occurs.kt
+++ b/src/com/amazon/ionschema/internal/constraint/Occurs.kt
@@ -80,7 +80,6 @@ internal open class Occurs(
     private val typeReference: () -> TypeInternal
     private var attempts = 0
     internal var validCount = 0
-    private val values = ion.system.newEmptyList()
 
     init {
         var occurs: IonValue? = null
@@ -121,8 +120,6 @@ internal open class Occurs(
         typeReference().validate(value, issues)
         validCount = attempts - issues.violations.size
         (issues as ViolationChild).addValue(value)
-
-        values.add(value.clone())
     }
 
     fun validateAttempts(issues: Violations) {


### PR DESCRIPTION
This cloned value doesn't seem to be used anywhere, and can be expensive
to compute.

For my test document, this reduced the time to validate from ~15 seconds
to around ~2 seconds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
