### PR TITLE
fix(cache): now actually caches Schema objects

### DIFF
--- a/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -41,7 +41,7 @@ internal class IonSchemaSystemImpl(
                 try {
                     authority.iteratorFor(this, id).use {
                         if (it.hasNext()) {
-                            return SchemaImpl(this, schemaCore, it)
+                            return@getOrPut SchemaImpl(this, schemaCore, it)
                         }
                     }
                 } catch (e: Exception) {

--- a/test/com/amazon/ionschema/IonSchemaSystemTest.kt
+++ b/test/com/amazon/ionschema/IonSchemaSystemTest.kt
@@ -79,6 +79,16 @@ class IonSchemaSystemTest {
     }
 
     @Test
+    fun loadSchema_verifyCache() {
+        val iss = IonSchemaSystemBuilder.standard()
+                .addAuthority(AuthorityFilesystem("ion-schema-tests"))
+                .build()
+        val schema = iss.loadSchema("schema/Customer.isl")
+        val schemaFromCache = iss.loadSchema("schema/Customer.isl")
+        assertTrue(schema == schemaFromCache)
+    }
+
+    @Test
     fun newSchema() {
         val schema = iss.newSchema()
         assertFalse(schema.getTypes().hasNext())


### PR DESCRIPTION
Resolves #129 by changing `return` to `return@getOrPut` so the cache actually gets populated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
