### PR TITLE
fix(authorityfs): restricts file access to be within the specified basePath only

### DIFF
--- a/src/com/amazon/ionschema/AuthorityFilesystem.kt
+++ b/src/com/amazon/ionschema/AuthorityFilesystem.kt
@@ -49,7 +49,8 @@ class AuthorityFilesystem(basePath: String) : Authority {
         val file = File(basePath, id)
 
         if (!file.canonicalPath.startsWith(basePath)) {
-            throw FileNotFoundException("$id (Permission denied)")
+            // constructing a new File here avoids leaking information about the filesystem
+            throw AccessDeniedException(File(id))
         }
 
         if (file.exists() && file.canRead()) {

--- a/src/com/amazon/ionschema/AuthorityFilesystem.kt
+++ b/src/com/amazon/ionschema/AuthorityFilesystem.kt
@@ -30,7 +30,7 @@ import java.io.Reader
  * @property[basePath] The base path in the filesystem in which to resolve schema identifiers.
  */
 class AuthorityFilesystem(basePath: String) : Authority {
-    private val canonicalBasePath: String
+    private val basePath: String
 
     init {
         val file = File(basePath)
@@ -38,7 +38,7 @@ class AuthorityFilesystem(basePath: String) : Authority {
             throw FileNotFoundException("Path '$basePath' does not exist")
         }
 
-        this.canonicalBasePath = if (file.canonicalPath.endsWith(File.separator)) {
+        this.basePath = if (file.canonicalPath.endsWith(File.separator)) {
             file.canonicalPath
         } else {
             file.canonicalPath + File.separator
@@ -46,9 +46,9 @@ class AuthorityFilesystem(basePath: String) : Authority {
     }
 
     override fun iteratorFor(iss: IonSchemaSystem, id: String): CloseableIterator<IonValue> {
-        val file = File(canonicalBasePath, id)
+        val file = File(basePath, id)
 
-        if (!file.canonicalPath.startsWith(canonicalBasePath)) {
+        if (!file.canonicalPath.startsWith(basePath)) {
             throw FileNotFoundException("$id (Permission denied)")
         }
 

--- a/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
+++ b/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
@@ -18,9 +18,10 @@ package com.amazon.ionschema
 import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
 import org.junit.Test
+import java.io.FileNotFoundException
 
 class AuthorityFilesystemTest {
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = FileNotFoundException::class)
     fun nonExistentPath() {
         AuthorityFilesystem("non-existent-path")
     }
@@ -37,6 +38,13 @@ class AuthorityFilesystemTest {
         } catch (e: NoSuchElementException) {
         }
         iter.close()
+    }
+
+    @Test(expected = FileNotFoundException::class)
+    fun iteratorFor_outsideBasePath() {
+        val iss = IonSchemaSystemBuilder.standard().build()
+        val authority = AuthorityFilesystem("ion-schema-tests/schema")
+        authority.iteratorFor(iss, "../core_types/any.isl")
     }
 }
 

--- a/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
+++ b/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
@@ -43,8 +43,8 @@ class AuthorityFilesystemTest {
     @Test(expected = FileNotFoundException::class)
     fun iteratorFor_outsideBasePath() {
         val iss = IonSchemaSystemBuilder.standard().build()
-        val authority = AuthorityFilesystem("ion-schema-tests/schema")
-        authority.iteratorFor(iss, "../core_types/any.isl")
+        var authority = AuthorityFilesystem("ion-schema-tests/schema")
+        authority.iteratorFor(iss, "../schema_private/some_file.isl")
     }
 }
 

--- a/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
+++ b/test/com/amazon/ionschema/AuthorityFilesystemTest.kt
@@ -40,7 +40,7 @@ class AuthorityFilesystemTest {
         iter.close()
     }
 
-    @Test(expected = FileNotFoundException::class)
+    @Test(expected = AccessDeniedException::class)
     fun iteratorFor_outsideBasePath() {
         val iss = IonSchemaSystemBuilder.standard().build()
         var authority = AuthorityFilesystem("ion-schema-tests/schema")


### PR DESCRIPTION
Resolves #132 

* throws `FileNotFoundException` if requested to resolve a schema id outside the `basePath`
* also changed the exception to throw the more appropriate `FileNotFoundException` (instead of `IllegalArgumentException`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
