### PR TITLE
feat(api): adds API for retrieving the types imported by a schema

### DIFF
--- a/src/com/amazon/ionschema/Import.kt
+++ b/src/com/amazon/ionschema/Import.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema
+
+/**
+ * An Import represents all the types imported by a Schema
+ * from one schema id.
+ *
+ * Note that multiple ISL imports referencing the same schema id
+ * (each importing/aliasing an individual type) are represented by a
+ * single Import instance.
+ */
+interface Import {
+    /**
+     * The schema id referenced by the import.
+     */
+    val id: String
+
+    /**
+     * Returns the requested type, if present in this import;
+     * otherwise returns null.  If a type is aliased (via "as")
+     * by the import, the type will only be returned from this
+     * method by its alias (not the imported type's original name).
+     */
+    fun getType(name: String): Type?
+
+    /**
+     * Returns an iterator over the types imported by this Import.
+     */
+    fun getTypes(): Iterator<Type>
+}
+

--- a/src/com/amazon/ionschema/Import.kt
+++ b/src/com/amazon/ionschema/Import.kt
@@ -25,9 +25,9 @@ package com.amazon.ionschema
  */
 interface Import {
     /**
-     * The schema id referenced by the import.
+     * Returns the schema referenced by the import.
      */
-    val id: String
+    fun getSchema(): Schema
 
     /**
      * Returns the requested type, if present in this import;
@@ -39,6 +39,8 @@ interface Import {
 
     /**
      * Returns an iterator over the types imported by this Import.
+     * Callers must not rely on any particular ordering, as Types
+     * may be returned in any order.
      */
     fun getTypes(): Iterator<Type>
 }

--- a/src/com/amazon/ionschema/Import.kt
+++ b/src/com/amazon/ionschema/Import.kt
@@ -25,6 +25,11 @@ package com.amazon.ionschema
  */
 interface Import {
     /**
+     * The id of the referenced schema.
+     */
+    val id: String
+
+    /**
      * Returns the schema referenced by the import.
      */
     fun getSchema(): Schema

--- a/src/com/amazon/ionschema/Schema.kt
+++ b/src/com/amazon/ionschema/Schema.kt
@@ -40,6 +40,20 @@ interface Schema {
     val isl: IonDatagram
 
     /**
+     * Returns an Import representing all the types imported from
+     * the specified schema [id].
+     */
+    fun getImport(id: String): Import?
+
+    /**
+     * Returns an iterator over the imports of this Schema.  Note that
+     * multiple ISL imports referencing the same schema id (to import
+     * individual types from the same schema id, for example) are
+     * represented by a single Import object.
+     */
+    fun getImports(): Iterator<Import>
+
+    /**
      * Returns the requested type, if present in this schema;
      * otherwise returns null.
      */

--- a/src/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/src/com/amazon/ionschema/internal/ImportImpl.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.ionschema.internal
 
 import com.amazon.ionschema.Import

--- a/src/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/src/com/amazon/ionschema/internal/ImportImpl.kt
@@ -1,6 +1,7 @@
 package com.amazon.ionschema.internal
 
 import com.amazon.ionschema.Import
+import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
 
 /**
@@ -8,11 +9,14 @@ import com.amazon.ionschema.Type
  */
 internal class ImportImpl(
         override val id: String,
-        private val types: Map<String, Type>
+        private val schema: Schema?,
+        private val types: Map<String, Type> = emptyMap()
 ) : Import {
 
-    override fun getType(name: String) = types[name]
+    override fun getType(name: String) = schema?.getType(name) ?: types[name]
 
-    override fun getTypes() = types.values.iterator()
+    override fun getTypes() =
+            ((schema?.getTypes()?.asSequence() ?: emptySequence())
+                    + types.values.asSequence()).iterator()
 }
 

--- a/src/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/src/com/amazon/ionschema/internal/ImportImpl.kt
@@ -24,6 +24,7 @@ import java.lang.IllegalArgumentException
  * Implementation of [Import] for all user-provided ISL.
  */
 internal class ImportImpl(
+        override val id: String,
         private val schema: Schema,
         private val importEntireSchema: Boolean,
         private val types: Map<String, Type>?

--- a/src/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/src/com/amazon/ionschema/internal/ImportImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionschema.internal
 import com.amazon.ionschema.Import
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
-import java.lang.IllegalArgumentException
 
 /**
  * Implementation of [Import] for all user-provided ISL.
@@ -26,30 +25,13 @@ import java.lang.IllegalArgumentException
 internal class ImportImpl(
         override val id: String,
         private val schema: Schema,
-        private val importEntireSchema: Boolean,
-        private val types: Map<String, Type>?
+        private val types: Map<String, Type>
 ) : Import {
-
-    init {
-        when {
-            !importEntireSchema && (types == null || types.isEmpty()) ->
-                throw IllegalArgumentException(
-                        "types to import must be provided when importEntireSchema is false")
-        }
-    }
 
     override fun getSchema() = schema
 
-    override fun getType(name: String): Type? = if (importEntireSchema) {
-        schema.getType(name) ?: types?.get(name)
-    } else {
-        types?.get(name)
-    }
+    override fun getType(name: String) = types[name]
 
-    override fun getTypes(): Iterator<Type> = if (importEntireSchema) {
-        (schema.getTypes().asSequence() + (types?.values?.asSequence() ?: emptySequence())).iterator()
-    } else {
-        types!!.values.iterator()
-    }
+    override fun getTypes(): Iterator<Type> = types.values.iterator()
 }
 

--- a/src/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/src/com/amazon/ionschema/internal/ImportImpl.kt
@@ -1,0 +1,18 @@
+package com.amazon.ionschema.internal
+
+import com.amazon.ionschema.Import
+import com.amazon.ionschema.Type
+
+/**
+ * Implementation of [Import] for all user-provided ISL.
+ */
+internal class ImportImpl(
+        override val id: String,
+        private val types: Map<String, Type>
+) : Import {
+
+    override fun getType(name: String) = types[name]
+
+    override fun getTypes() = types.values.iterator()
+}
+

--- a/src/com/amazon/ionschema/internal/SchemaCore.kt
+++ b/src/com/amazon/ionschema/internal/SchemaCore.kt
@@ -16,6 +16,7 @@
 package com.amazon.ionschema.internal
 
 import com.amazon.ion.*
+import com.amazon.ionschema.Import
 import com.amazon.ionschema.IonSchemaSystem
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
@@ -57,6 +58,10 @@ internal class SchemaCore(
         } else {
             TypeCore(name)
         }
+
+    override fun getImport(id: String) = null
+
+    override fun getImports() = emptyList<Import>().iterator()
 
     override fun getType(name: String): Type? = typeMap[name]
 

--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -21,6 +21,7 @@ import com.amazon.ion.IonString
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonValue
+import com.amazon.ionschema.Import
 import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
@@ -33,6 +34,7 @@ internal class SchemaImpl private constructor(
         private val schemaSystem: IonSchemaSystemImpl,
         private val schemaCore: SchemaCore,
         schemaContent: Iterator<IonValue>,
+        preloadedImports: Map<String, Import>,
         /*
          * [types] is declared as a MutableMap in order to be populated DURING
          * INITIALIZATION ONLY.  This enables type B to find its already-loaded
@@ -46,11 +48,13 @@ internal class SchemaImpl private constructor(
         schemaSystem: IonSchemaSystemImpl,
         schemaCore: SchemaCore,
         schemaContent: Iterator<IonValue>
-    ) : this(schemaSystem, schemaCore, schemaContent, mutableMapOf())
+    ) : this(schemaSystem, schemaCore, schemaContent, emptyMap(), mutableMapOf())
 
     private val deferredTypeReferences = mutableListOf<TypeReferenceDeferred>()
 
     override val isl: IonDatagram
+
+    private val imports: Map<String, Import>
 
     init {
         val dgIsl = schemaSystem.getIonSystem().newDatagram()
@@ -58,6 +62,7 @@ internal class SchemaImpl private constructor(
         if (types.isEmpty()) {
             var foundHeader = false
             var foundFooter = false
+            var importsMap = emptyMap<String, Import>()
 
             while (schemaContent.hasNext()) {
                 val it = schemaContent.next()
@@ -68,7 +73,7 @@ internal class SchemaImpl private constructor(
                     // TBD https://github.com/amzn/ion-schema-kotlin/issues/95
 
                 } else if (it.hasTypeAnnotation("schema_header")) {
-                    loadHeader(types, it as IonStruct)
+                    importsMap = loadHeader(types, it as IonStruct)
                     foundHeader = true
 
                 } else if (!foundFooter && it.hasTypeAnnotation("type") && it is IonStruct) {
@@ -88,6 +93,7 @@ internal class SchemaImpl private constructor(
             }
 
             resolveDeferredTypeReferences()
+            imports = importsMap
 
         } else {
             // in this case the new Schema is based on an existing Schema and the 'types'
@@ -95,16 +101,21 @@ internal class SchemaImpl private constructor(
             schemaContent.forEach {
                 dgIsl.add(it.clone())
             }
+            imports = preloadedImports
         }
 
         isl = dgIsl.markReadOnly()
     }
 
-    private fun loadHeader(typeMap: MutableMap<String, Type>, header: IonStruct) {
+    private fun loadHeader(typeMap: MutableMap<String, Type>,
+                           header: IonStruct): Map<String, Import> {
+
+        val importsMap = mutableMapOf<String, MutableMap<String, Type>>()
         (header.get("imports") as? IonList)
             ?.filterIsInstance<IonStruct>()
             ?.forEach {
                 val id = it["id"] as IonString
+                val importedTypes = importsMap.getOrPut(id.stringValue()) { mutableMapOf() }
                 val importedSchema = schemaSystem.loadSchema(id.stringValue())
 
                 val typeName = (it["type"] as? IonSymbol)?.stringValue()
@@ -118,13 +129,21 @@ internal class SchemaImpl private constructor(
                         newType = TypeAliased(alias, newType as TypeInternal)
                     }
                     addType(typeMap, newType)
+                    importedTypes[alias?.stringValue() ?: typeName] = newType
                 } else {
-                    importedSchema.getTypes().forEach {
-                        addType(typeMap, it)
+                    importedSchema.getTypes().forEach { type ->
+                        addType(typeMap, type)
+                        importedTypes[type.name] = type
                     }
                 }
             }
+
+        return importsMap.mapValues { ImportImpl(it.key, it.value) }
     }
+
+    override fun getImport(id: String) = imports[id]
+
+    override fun getImports() = imports.values.iterator()
 
     private fun validateType(type: Type) {
         if (!schemaSystem.hasParam(IonSchemaSystemImpl.Param.ALLOW_ANONYMOUS_TOP_LEVEL_TYPES)) {
@@ -191,7 +210,7 @@ internal class SchemaImpl private constructor(
         // clone the types map:
         val preLoadedTypes = types.toMutableMap()
         preLoadedTypes[type.name] = type
-        return SchemaImpl(schemaSystem, schemaCore, newIsl.iterator(), preLoadedTypes)
+        return SchemaImpl(schemaSystem, schemaCore, newIsl.iterator(), imports, preLoadedTypes)
     }
 
     override fun getSchemaSystem() = schemaSystem

--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -107,7 +107,7 @@ internal class SchemaImpl private constructor(
         isl = dgIsl.markReadOnly()
     }
 
-    private class SchemaAndTypeImports(val schema: Schema) {
+    private class SchemaAndTypeImports(val id: String, val schema: Schema) {
         var importEntireSchema = false
         var types: MutableMap<String,Type>? = null
 
@@ -129,7 +129,7 @@ internal class SchemaImpl private constructor(
                 val id = it["id"] as IonString
                 val importedSchema = schemaSystem.loadSchema(id.stringValue())
                 val schemaAndTypes = importsMap.getOrPut(id.stringValue()) {
-                    SchemaAndTypeImports(importedSchema)
+                    SchemaAndTypeImports(id.stringValue(), importedSchema)
                 }
 
                 val typeName = (it["type"] as? IonSymbol)?.stringValue()
@@ -153,7 +153,7 @@ internal class SchemaImpl private constructor(
             }
 
         return importsMap.mapValues {
-            ImportImpl(it.value.schema, it.value.importEntireSchema, it.value.types)
+            ImportImpl(it.value.id, it.value.schema, it.value.importEntireSchema, it.value.types)
         }
     }
 

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -35,7 +35,9 @@ class SchemaImportTest {
     @Test
     fun getImport_entire_schema() {
         val schema = iss.loadSchema("schema/import/import.isl")
-        val import = schema.getImport("schema/import/abcde.isl")!!
+        val schemaId = "schema/import/abcde.isl"
+        val import = schema.getImport(schemaId)!!
+        assertEquals(schemaId, import.id)
         assertEquals(5, import.getTypes().asSequence().count())
         assertEquals(5, import.getSchema().getTypes().asSequence().count())
         import.getTypes().forEach {
@@ -47,7 +49,9 @@ class SchemaImportTest {
     @Test
     fun getImport_type() {
         val schema = iss.loadSchema("schema/import/import_type.isl")
-        val import = schema.getImport("schema/util/positive_int.isl")!!
+        val schemaId = "schema/util/positive_int.isl"
+        val import = schema.getImport(schemaId)!!
+        assertEquals(schemaId, import.id)
         assertEquals(1, import.getTypes().asSequence().count())
         val type = import.getType("positive_int")!!
         assertEquals("positive_int", type.name)
@@ -65,6 +69,7 @@ class SchemaImportTest {
         val schema = iss.loadSchema("schema/import/import_type_by_alias.isl")
         assertEquals(1, schema.getImports().asSequence().count())
         val import = schema.getImports().next()
+        assertEquals("schema/util/positive_int.isl", import.id)
         assertEquals(2, import.getTypes().asSequence().count())
         assertNotNull(import.getType("positive_int_1"))
         assertNotNull(import.getType("positive_int_2"))
@@ -81,6 +86,7 @@ class SchemaImportTest {
         assertEquals(keys.size, schema.getImports().asSequence().count())
         keys.entries.forEach { entry ->
             val import = schema.getImport(entry.key)!!
+            assertEquals(entry.key, import.id)
             assertEquals(entry.value.size, import.getTypes().asSequence().count())
             entry.value.forEach {
                 val type = import.getType(it)!!

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema
+
+import org.junit.Assert.*
+import org.junit.Test
+import com.amazon.ion.system.IonSystemBuilder
+
+class SchemaImportTest {
+    private val ION = IonSystemBuilder.standard().build()
+
+    private val iss = IonSchemaSystemBuilder.standard()
+            .addAuthority(AuthorityFilesystem("ion-schema-tests"))
+            .build()
+
+    @Test
+    fun getImport_unknown() {
+        val schema = iss.loadSchema("schema/import/import.isl")
+        assertNull(schema.getImport("unknown_id"))
+    }
+
+    @Test
+    fun getImport_entire_schema() {
+        val schema = iss.loadSchema("schema/import/import.isl")
+        val id = "schema/import/abcde.isl"
+        val import = schema.getImport(id)!!
+        assertEquals(id, import.id)
+
+        assertEquals(5, import.getTypes().asSequence().count())
+        import.getTypes().forEach {
+            val type = import.getType(it.name)
+            assertNotNull(type)
+        }
+    }
+
+    @Test
+    fun getImport_type() {
+        val schema = iss.loadSchema("schema/import/import_type.isl")
+        val id = "schema/util/positive_int.isl"
+        val import = schema.getImport(id)!!
+        assertEquals(id, import.id)
+
+        assertEquals(1, import.getTypes().asSequence().count())
+        val type = import.getType("positive_int")!!
+        assertEquals("positive_int", type.name)
+    }
+
+    @Test
+    fun getImport_multiple_aliased_types() {
+        val schema = iss.loadSchema("schema/import/import_types.isl")
+        val keys = mapOf(
+                "schema/import/abcde.isl"      to setOf("a2", "b", "c2"),
+                "schema/util/positive_int.isl" to setOf("positive_int", "posint"))
+
+        assertEquals(keys.size, schema.getImports().asSequence().count())
+        keys.entries.forEach { entry ->
+            val import = schema.getImport(entry.key)!!
+            assertEquals(entry.value.size, import.getTypes().asSequence().count())
+            entry.value.forEach {
+                val type = import.getType(it)!!
+                assertEquals(it, type.name)
+            }
+        }
+    }
+
+    @Test
+    fun getImports_none() {
+        val schema = iss.loadSchema("schema/byte_length.isl")
+        assertEquals(0, schema.getImports().asSequence().count())
+    }
+
+    @Test
+    fun getImports() {
+        val schema = iss.loadSchema("schema/import/import_type_by_alias.isl")
+        assertEquals(1, schema.getImports().asSequence().count())
+        val import = schema.getImports().next()
+        assertEquals("schema/util/positive_int.isl", import.id)
+    }
+}
+

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -35,11 +35,9 @@ class SchemaImportTest {
     @Test
     fun getImport_entire_schema() {
         val schema = iss.loadSchema("schema/import/import.isl")
-        val id = "schema/import/abcde.isl"
-        val import = schema.getImport(id)!!
-        assertEquals(id, import.id)
-
+        val import = schema.getImport("schema/import/abcde.isl")!!
         assertEquals(5, import.getTypes().asSequence().count())
+        assertEquals(5, import.getSchema().getTypes().asSequence().count())
         import.getTypes().forEach {
             val type = import.getType(it.name)
             assertNotNull(type)
@@ -49,17 +47,32 @@ class SchemaImportTest {
     @Test
     fun getImport_type() {
         val schema = iss.loadSchema("schema/import/import_type.isl")
-        val id = "schema/util/positive_int.isl"
-        val import = schema.getImport(id)!!
-        assertEquals(id, import.id)
-
+        val import = schema.getImport("schema/util/positive_int.isl")!!
         assertEquals(1, import.getTypes().asSequence().count())
         val type = import.getType("positive_int")!!
         assertEquals("positive_int", type.name)
+        assertNotNull(import.getSchema())
     }
 
     @Test
-    fun getImport_multiple_aliased_types() {
+    fun getImports_none() {
+        val schema = iss.loadSchema("schema/byte_length.isl")
+        assertEquals(0, schema.getImports().asSequence().count())
+    }
+
+    @Test
+    fun getImports() {
+        val schema = iss.loadSchema("schema/import/import_type_by_alias.isl")
+        assertEquals(1, schema.getImports().asSequence().count())
+        val import = schema.getImports().next()
+        assertEquals(2, import.getTypes().asSequence().count())
+        assertNotNull(import.getType("positive_int_1"))
+        assertNotNull(import.getType("positive_int_2"))
+        assertNotNull(import.getSchema().getType("positive_int"))
+    }
+
+    @Test
+    fun getImports_multiple_aliased_types() {
         val schema = iss.loadSchema("schema/import/import_types.isl")
         val keys = mapOf(
                 "schema/import/abcde.isl"      to setOf("a2", "b", "c2"),
@@ -74,20 +87,11 @@ class SchemaImportTest {
                 assertEquals(it, type.name)
             }
         }
-    }
 
-    @Test
-    fun getImports_none() {
-        val schema = iss.loadSchema("schema/byte_length.isl")
-        assertEquals(0, schema.getImports().asSequence().count())
-    }
-
-    @Test
-    fun getImports() {
-        val schema = iss.loadSchema("schema/import/import_type_by_alias.isl")
-        assertEquals(1, schema.getImports().asSequence().count())
-        val import = schema.getImports().next()
-        assertEquals("schema/util/positive_int.isl", import.id)
+        assertEquals(1, schema.getImport("schema/util/positive_int.isl")!!.getSchema()
+                .getTypes().asSequence().count())
+        assertEquals(5, schema.getImport("schema/import/abcde.isl")!!.getSchema()
+                .getTypes().asSequence().count())
     }
 }
 

--- a/test/com/amazon/ionschema/SchemaTest.kt
+++ b/test/com/amazon/ionschema/SchemaTest.kt
@@ -132,6 +132,16 @@ class SchemaTest {
     }
 
     @Test
+    fun plusType_imports_retained() {
+        val schema = iss.loadSchema("schema/import/import_types.isl")
+        assertEquals(2, schema.getImports().asSequence().count())
+        val newType = schema.newType("type::{name: three, value_values: [3], open_content: 3}")
+        val newSchema = schema.plusType(newType)
+        assertEquals(schema.getImports().asSequence().toList(),
+                newSchema.getImports().asSequence().toList())
+    }
+
+    @Test
     fun param_allow_anonymous_top_level_types() {
         val iss = IonSchemaSystemBuilder.standard()
                 .allowAnonymousTopLevelTypes()


### PR DESCRIPTION
Resolves #137 

#143 enabled callers to retrieve the ISL underlying Schema and Type objects.  This PR enables callers to retrieve schemas and types *imported* by a schema (and thereby gain access to the underlying ISL of those objects).

Prior to merging:  update the ion-schema-tests submodule after merging https://github.com/amzn/ion-schema-tests/pull/3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
