### PR TITLE
adds graceful handling of redundant imports

### DIFF
--- a/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/src/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -43,7 +43,7 @@ internal class IonSchemaSystemImpl(
                 try {
                     authority.iteratorFor(this, id).use {
                         if (it.hasNext()) {
-                            return@getOrPut SchemaImpl(this, schemaCore, it)
+                            return@getOrPut SchemaImpl(this, schemaCore, it, id)
                         }
                     }
                 } catch (e: Exception) {
@@ -62,7 +62,7 @@ internal class IonSchemaSystemImpl(
 
     override fun newSchema(isl: String) = newSchema(ION.iterate(isl))
 
-    override fun newSchema(isl: Iterator<IonValue>) = SchemaImpl(this, schemaCore, isl)
+    override fun newSchema(isl: Iterator<IonValue>) = SchemaImpl(this, schemaCore, isl, null)
 
     internal fun isConstraint(name: String)
             = constraintFactory.isConstraint(name)

--- a/src/com/amazon/ionschema/internal/TypeCore.kt
+++ b/src/com/amazon/ionschema/internal/TypeCore.kt
@@ -40,6 +40,8 @@ internal class TypeCore(
 
     override val name = ionTypeName
 
+    override val schemaId: String? = null
+
     override val isl = nameSymbol.markReadOnly()
 
     override fun getBaseType() = this

--- a/src/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/src/com/amazon/ionschema/internal/TypeImpl.kt
@@ -59,6 +59,8 @@ internal class TypeImpl(
 
     override val name = (ionStruct.get("name") as? IonSymbol)?.stringValue() ?: ionStruct.toString()
 
+    override val schemaId: String? = (schema as? SchemaImpl)?.schemaId
+
     override fun getBaseType(): TypeBuiltin {
         val type = ionStruct["type"]
         if (type != null && type is IonSymbol) {

--- a/src/com/amazon/ionschema/internal/TypeInternal.kt
+++ b/src/com/amazon/ionschema/internal/TypeInternal.kt
@@ -22,8 +22,21 @@ import com.amazon.ionschema.Type
  * Internal methods for interacting with [Type]s.
  */
 internal interface TypeInternal : Type, Constraint {
+
+    /**
+     * The name of the schemaId that this type was defined in.
+     */
+    val schemaId: String?
+
     fun getBaseType(): TypeBuiltin
 
     fun isValidForBaseType(value: IonValue): Boolean
 }
 
+/**
+ * The name of the schemaId that this type was defined in.
+ *
+ * Even though it is not part of the public API, it is convenient to have [schemaId] available on [Type] internally.
+ */
+internal val Type.schemaId: String?
+    get() = (this as? TypeInternal)?.schemaId

--- a/src/com/amazon/ionschema/internal/TypeIon.kt
+++ b/src/com/amazon/ionschema/internal/TypeIon.kt
@@ -35,6 +35,8 @@ internal class TypeIon(
 
     override val name = nameSymbol.stringValue()
 
+    override val schemaId: String? = null
+
     override val isl = nameSymbol.markReadOnly()
 
     override fun getBaseType() = this

--- a/src/com/amazon/ionschema/internal/TypeReference.kt
+++ b/src/com/amazon/ionschema/internal/TypeReference.kt
@@ -103,6 +103,7 @@ internal class TypeReferenceDeferred(
 
     private var type: TypeInternal? = null
     override val name: String = nameSymbol.stringValue()
+    override val schemaId: String? = (schema as? SchemaImpl)?.schemaId
     override val isl = nameSymbol.markReadOnly()
 
     fun attemptToResolve(): Boolean {

--- a/test/com/amazon/ionschema/IonSchemaTestRunner.kt
+++ b/test/com/amazon/ionschema/IonSchemaTestRunner.kt
@@ -70,7 +70,7 @@ class IonSchemaTestRunner(
                     when (annotation) {
                         "schema_header" -> {
                             iter.previous()
-                            schema = SchemaImpl(schemaSystem as IonSchemaSystemImpl, schemaCore, iter)
+                            schema = SchemaImpl(schemaSystem as IonSchemaSystemImpl, schemaCore, iter, testName)
                         }
 
                         "type" ->
@@ -110,7 +110,7 @@ class IonSchemaTestRunner(
                             runTest(notifier, testName, ion) {
                                 try {
                                     SchemaImpl(schemaSystem as IonSchemaSystemImpl, schemaCore,
-                                            (prepareValue(ion) as IonSequence).iterator())
+                                            (prepareValue(ion) as IonSequence).iterator(), testName)
                                     fail("Expected an InvalidSchemaException")
                                 } catch (e: InvalidSchemaException) {
                                 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amzn/ion-schema-kotlin/issues/117

*Description of changes:*
Adds graceful handling of redundant imports by checking the schemaId of a type. If two types have the same name and the same schemaId, it is considered a redundant important and is ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
