### PR TITLE
Bumps kotlin version in build.gradle to 1.3.72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-  id "org.jetbrains.kotlin.jvm" version "1.3.21"
+  id "org.jetbrains.kotlin.jvm" version "1.3.72"
   id "org.jetbrains.dokka" version "0.9.18"
   id "maven-publish"
   id "signing"


### PR DESCRIPTION
*Description of changes:*

I noticed that the Travis build failed on PR #151 , which only changed the README. This indicates that something external changed in Travis, which began complaining about the Kotlin version. Maybe this will fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
