### PR TITLE
Schema import id normalize

### DIFF
--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -20,6 +20,7 @@ import com.amazon.ion.IonList
 import com.amazon.ion.IonString
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonType
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Import
 import com.amazon.ionschema.InvalidSchemaException
@@ -131,7 +132,7 @@ internal class SchemaImpl private constructor(
         (header.get("imports") as? IonList)
             ?.filterIsInstance<IonStruct>()
             ?.forEach {
-                val id = it["id"] as IonString
+                val id = if(it["id"].type == IonType.SYMBOL) it["id"] as IonSymbol else it["id"] as IonString
                 val importedSchema = schemaSystem.loadSchema(id.stringValue())
                 val schemaAndTypes = importsMap.getOrPut(id.stringValue()) {
                     SchemaAndTypeImports(id.stringValue(), importedSchema)

--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -20,7 +20,7 @@ import com.amazon.ion.IonList
 import com.amazon.ion.IonString
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonSymbol
-import com.amazon.ion.IonType
+import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Import
 import com.amazon.ionschema.InvalidSchemaException
@@ -132,7 +132,7 @@ internal class SchemaImpl private constructor(
         (header.get("imports") as? IonList)
             ?.filterIsInstance<IonStruct>()
             ?.forEach {
-                val id = if(it["id"].type == IonType.SYMBOL) it["id"] as IonSymbol else it["id"] as IonString
+                val id = it["id"] as IonText
                 val importedSchema = schemaSystem.loadSchema(id.stringValue())
                 val schemaAndTypes = importsMap.getOrPut(id.stringValue()) {
                     SchemaAndTypeImports(id.stringValue(), importedSchema)

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -47,7 +47,7 @@ class SchemaImportTest {
     }
 
     @Test
-    fun demo() {
+    fun getImport_new_schema_from_symbol() {
         val test = "schema_header::{ imports: [ {id: 'schema/import/abcde.isl' }] } schema_footer::{}"
         val ion = IonSystemBuilder.standard().build()
         val iss = IonSchemaSystemBuilder.standard().addAuthority(AuthorityFilesystem("ion-schema-tests")).withIonSystem(ion).build()

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -47,6 +47,14 @@ class SchemaImportTest {
     }
 
     @Test
+    fun demo() {
+        val test = "schema_header::{ imports: [ {id: 'schema/import/abcde.isl' }] } schema_footer::{}"
+        val ion = IonSystemBuilder.standard().build()
+        val iss = IonSchemaSystemBuilder.standard().addAuthority(AuthorityFilesystem("ion-schema-tests")).withIonSystem(ion).build()
+        val schema = iss.newSchema(ion.iterate(test))
+    }
+
+    @Test
     fun getImport_type() {
         val schema = iss.loadSchema("schema/import/import_type.isl")
         val schemaId = "schema/util/positive_int.isl"

--- a/test/com/amazon/ionschema/SchemaImportTest.kt
+++ b/test/com/amazon/ionschema/SchemaImportTest.kt
@@ -47,11 +47,16 @@ class SchemaImportTest {
     }
 
     @Test
-    fun getImport_new_schema_from_symbol() {
+    fun getImport_id_is_a_symbol() {
         val test = "schema_header::{ imports: [ {id: 'schema/import/abcde.isl' }] } schema_footer::{}"
         val ion = IonSystemBuilder.standard().build()
         val iss = IonSchemaSystemBuilder.standard().addAuthority(AuthorityFilesystem("ion-schema-tests")).withIonSystem(ion).build()
         val schema = iss.newSchema(ion.iterate(test))
+        val schemaId = "schema/import/abcde.isl"
+        val import = schema.getImport(schemaId)!!
+        assertEquals(schemaId, import.id)
+        assertEquals(5, import.getTypes().asSequence().count())
+        assertNotNull(import.getSchema())
     }
 
     @Test


### PR DESCRIPTION
*Issue #153*

*Description of changes:*
This PR works on loading schema with symbol or string as ID according to the [spec](https://amzn.github.io/ion-schema/docs/spec.html#grammar). 

*Task:*

1. Inside `loadHeader` method, store ID as `IonSymbol` or `IonString` based on the input. 

*Test:*
getImport_new_schema_from_symbol:  added a unit test for verification.