### PR TITLE
Updated testSuite to pass filename as id instead of testName

### DIFF
--- a/test/com/amazon/ionschema/IonSchemaTestRunner.kt
+++ b/test/com/amazon/ionschema/IonSchemaTestRunner.kt
@@ -60,7 +60,8 @@ class IonSchemaTestRunner(
             .filter { it.path.endsWith(".isl") }
             .filter { !blacklist.contains(it.path) }
             .forEach { file ->
-                val testName = file.path.substring(base.length + 1, file.path.length)
+                val testName = file.path.substring(base.length + 1, file.path.length - ".isl".length)
+                val testFile = file.path.substring(base.length + 1, file.path.length)
                 var schema: Schema? = null
                 var type: Type? = null
 
@@ -70,7 +71,7 @@ class IonSchemaTestRunner(
                     when (annotation) {
                         "schema_header" -> {
                             iter.previous()
-                            schema = SchemaImpl(schemaSystem as IonSchemaSystemImpl, schemaCore, iter, testName)
+                            schema = SchemaImpl(schemaSystem as IonSchemaSystemImpl, schemaCore, iter, testFile)
                         }
 
                         "type" ->

--- a/test/com/amazon/ionschema/IonSchemaTestRunner.kt
+++ b/test/com/amazon/ionschema/IonSchemaTestRunner.kt
@@ -60,7 +60,7 @@ class IonSchemaTestRunner(
             .filter { it.path.endsWith(".isl") }
             .filter { !blacklist.contains(it.path) }
             .forEach { file ->
-                val testName = file.path.substring(base.length + 1, file.path.length - ".isl".length)
+                val testName = file.path.substring(base.length + 1, file.path.length)
                 var schema: Schema? = null
                 var type: Type? = null
 


### PR DESCRIPTION
*Description of changes:*
In order to solve the cyclic dependency issue (specified by [this PR](https://github.com/amzn/ion-schema-kotlin/pull/157)), we have to change the way the schemaId is passed in the testSuite.
 
**Changes:**
1. Instead of using the `testName` stating file path without  '.isl', will be using `testName` with the '.isl' inside `IonSchemaTestRunner`. 
2. This will allow the cyclic dependency check to have a unique Id pattern followed, which can help in defining equality of import ids.