### PR TITLE
adding changes for utf8_byte_length constraint

### DIFF
--- a/src/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/src/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -44,6 +44,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
         timestamp_offset,
         timestamp_precision,
         type,
+        utf8_byte_length,
         valid_values,
     }
 
@@ -77,6 +78,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
             Constraints.timestamp_offset    -> TimestampOffset(ion)
             Constraints.timestamp_precision -> TimestampPrecision(ion)
             Constraints.type                -> Type(ion, schema)
+            Constraints.utf8_byte_length    -> Utf8ByteLength(ion)
             Constraints.valid_values        -> ValidValues(ion)
         }
 }

--- a/src/com/amazon/ionschema/internal/constraint/Utf8ByteLength.kt
+++ b/src/com/amazon/ionschema/internal/constraint/Utf8ByteLength.kt
@@ -1,0 +1,41 @@
+package com.amazon.ionschema.internal.constraint
+import com.amazon.ion.IonText
+import com.amazon.ion.IonValue
+
+/**
+ * Implements the utf8_byte_length constraint.
+ */
+internal class Utf8ByteLength(
+        ion: IonValue
+) : ConstraintBaseIntRange<IonText>(IonText::class.java, ion) {
+
+    override val violationCode = "invalid_utf8_byte_length"
+    override val violationMessage = "invalid utf8 byte length %s, expected %s"
+
+    override fun getIntValue(value: IonText) = byteLength(value.stringValue())
+
+    private fun byteLength(cs: CharSequence): Int {
+        var count = 0
+        var skipLowSurrogate = false
+        for (c in cs) {
+            if (skipLowSurrogate) {
+                count += 2
+                skipLowSurrogate = false
+            } else {
+                val cValue = c.toInt()
+                if (cValue < 0x80) {
+                    count++
+                } else if (cValue < 0x800) {
+                    count += 2
+                } else if (c.isHighSurrogate()) {
+                    count += 2
+                    skipLowSurrogate = true
+                } else {
+                    count += 3
+                }
+            }
+        }
+
+        return count
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR adds a new constraint `utf8_byte_length` for the number of bytes to allow a particular value or range of values in the UTF8 representation of a string.

*Test:*
https://github.com/amzn/ion-schema-tests/pull/7

*Schema:*
https://github.com/amzn/ion-schema-schemas/pull/3

*Schema Documentation:*
https://github.com/amzn/ion-schema/pull/32