### PR TITLE
Fixes a bug in IonSchemaTestRunner that caused it to silently ignore some test cases

### DIFF
--- a/test/com/amazon/ionschema/AbstractTestRunner.kt
+++ b/test/com/amazon/ionschema/AbstractTestRunner.kt
@@ -46,7 +46,7 @@ abstract class AbstractTestRunner(
             test()
         } catch (ae: AssertionError) {
             notifier.fireTestFailure(Failure(desc, ae))
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             notifier.fireTestFailure(Failure(desc, e))
         } finally {
             notifier.fireTestFinished(desc)


### PR DESCRIPTION
**Issue #, if available:**
N/A


**Description of changes:**

Given a [schema definition test](https://github.com/amzn/ion-schema-tests#user-content-schema-definition-test) like this:

```
schema_header::{}
type::{
  name: Foo,
  type: struct,
  fields: {
    a: int,
    b: string,
  }
}
schema_footer::{}

valid::{
  Foo: [
    { a: 1, b: "hello" },
    { a: 2, b: "world", c: "open content" },
  ],
}

invalid::{
  Foo: [
    { a: "should be int", b: "a string" },
    { a: 1, b: a_symbol },
  ],
}
```
The `IonSchemaTestRunner` would discover the schema header, and pass the sequence of ion values to the `SchemaImpl` constructor. Because ISL itself allows open content, the `SchemaImpl` would consume _all_ the ion values from the test file—including the `valid::` and `invalid::` test cases. Then the test runner tries to run the test cases on the schema, but the sequence of ion values has already been drained, so there is nothing left for it to run.

My change fixes `IonSchemaTestRunner` so that it will detect if a `schema_header` is present in a test file, and if there is, then the `IonSchemaTestRunner` will split the sequence of ion values into "schema" and "test inputs", passing the schema ion to the schema constructor, and retaining the test inputs for running the test cases.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
