### PR TITLE
Fixes a bug that allowed conflicting type definitions in a single schema

### DIFF
--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -110,7 +110,7 @@ internal class SchemaImpl private constructor(
 
         fun addType(name: String, type: Type) {
             types[name]?.let {
-                if (it.schemaId != type.schemaId) {
+                if (it.schemaId != type.schemaId || it.isl != type.isl) {
                     throw InvalidSchemaException("Duplicate imported type name/alias encountered: '$name'")
                 }
                 return@addType
@@ -195,7 +195,7 @@ internal class SchemaImpl private constructor(
     private fun addType(typeMap: MutableMap<String, Type>, type: Type) {
         validateType(type)
         getType(type.name)?.let {
-            if (it.schemaId != type.schemaId) {
+            if (it.schemaId != type.schemaId || it.isl != type.isl) {
                 throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
             }
             return@addType

--- a/test/com/amazon/ionschema/ISLforISLTestRunner.kt
+++ b/test/com/amazon/ionschema/ISLforISLTestRunner.kt
@@ -38,6 +38,8 @@ class ISLforISLTestRunner(
         .withAuthority(AuthorityFilesystem("ion-schema-schemas"))
         .build()
 
+    // There are certain conditions that make a schema invalid that cannot be detected by the ISL for ISL (for example, a schema importing itself).
+    // Test files with "invalid_schema" definitions should be listed here if and only if they are invalid for some reason that cannot be validated by ISL.
     private val blacklist = setOf(
         "ion-schema-tests/schema/import/import_schema_with_aliased_type_invalid.isl",
         "ion-schema-tests/schema/import/import_type_unknown.isl",
@@ -46,6 +48,7 @@ class ISLforISLTestRunner(
         "ion-schema-tests/schema/import/invalid_duplicate_type.isl",
         "ion-schema-tests/schema/invalid_missing_schema_footer.isl",
         "ion-schema-tests/schema/invalid_missing_schema_header.isl",
+        "ion-schema-tests/schema/invalid_reuse_of_type_name.isl",
         "ion-schema-tests/schema/invalid_unknown_type.isl"
     )
 

--- a/test/com/amazon/ionschema/ISLforISLTestRunner.kt
+++ b/test/com/amazon/ionschema/ISLforISLTestRunner.kt
@@ -38,8 +38,10 @@ class ISLforISLTestRunner(
         .withAuthority(AuthorityFilesystem("ion-schema-schemas"))
         .build()
 
-    // There are certain conditions that make a schema invalid that cannot be detected by the ISL for ISL (for example, a schema importing itself).
-    // Test files with "invalid_schema" definitions should be listed here if and only if they are invalid for some reason that cannot be validated by ISL.
+    // There are certain conditions that make a schema invalid that cannot
+    // be detected by the ISL for ISL (for example, a schema importing itself).
+    // Test files with "invalid_schema" definitions should be listed here if and
+    // only if they are invalid for some reason that cannot be validated by ISL.
     private val blacklist = setOf(
         "ion-schema-tests/schema/import/import_schema_with_aliased_type_invalid.isl",
         "ion-schema-tests/schema/import/import_type_unknown.isl",


### PR DESCRIPTION
_Description of changes:_

Fixes a bug that allowed you to define two types with the same name in a single schema ([example of what should not be allowed](https://github.com/amzn/ion-schema-tests/pull/12/files#diff-f1583845208143a2c16e9f91fe8141073f6985e3f6c75367b8f2b25fafd9e1b4)). When there are two types with the same name _in the same schema_, the current behavior is that one will silently overwrite the other.

This change does not protect against the case where the type is an exact copy. Eg.
```
schema_header::{
    // ...
}

type::{ name: foo, type: int }
type::{ name: foo, type: int }

schema_footer::{}
```
However, this example (even though it is not supposed to be allowed) is not going to lead to any undefined or unexpected behavior.



_Tests:_ amzn/ion-schema-tests#12
_Schema:_ N/A
_Schema Documentation:_ N/A

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
