### PR TITLE
Adds ion-schema-schemas to the ion-schema-kotlin jar and provides an Authority for accessing them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ sourceSets {
   test.kotlin.srcDirs = ["test"]
 }
 
+processResources {
+  from('ion-schema-schemas/isl/') {
+    into 'ion-schema-schemas/isl/'
+  }
+}
+
 ktlint {
   outputToConsole = true
 }

--- a/src/com/amazon/ionschema/ResourceAuthority.kt
+++ b/src/com/amazon/ionschema/ResourceAuthority.kt
@@ -1,0 +1,43 @@
+package com.amazon.ionschema
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.IonSchemaSystemImpl
+import com.amazon.ionschema.util.CloseableIterator
+import java.io.Closeable
+import java.io.InputStream
+
+/**
+ * An [Authority] implementation that attempts to resolve schema ids to resources
+ * in a [ClassLoader]'s classpath.
+ *
+ * @property[rootPackage] The base path within the [ClassLoader]'s classpath in which
+ *     to resolve schema identifiers.
+ * @property[classLoader] The [ClassLoader] to use to find the schema resources.
+ */
+class ResourceAuthority(
+    rootPackage: String,
+    private val classLoader: ClassLoader
+) : Authority {
+    private val rootPackage = if (rootPackage.endsWith('/')) rootPackage else "$rootPackage/"
+
+    override fun iteratorFor(iss: IonSchemaSystem, id: String): CloseableIterator<IonValue> {
+        val resourceName = "$rootPackage/$id"
+        val stream: InputStream = classLoader.getResourceAsStream(resourceName) ?: return EMPTY_ITERATOR
+
+        val ion = (iss as IonSchemaSystemImpl).getIonSystem()
+        val reader = ion.newReader(stream)
+
+        return object : CloseableIterator<IonValue>, Iterator<IonValue> by ion.iterate(reader), Closeable by reader {
+            // Intentionally empty body because this object has all its methods implemented by delegation.
+        }
+    }
+
+    companion object {
+        /**
+         * Factory method for constructing a [ResourceAuthority] that can access the schemas provided by
+         * [`ion-schema-schemas`](https://github.com/amzn/ion-schema-schemas/).
+         */
+        @JvmStatic
+        fun forIonSchemaSchemas(): ResourceAuthority = ResourceAuthority("ion-schema-schemas", ResourceAuthority::class.java.classLoader)
+    }
+}

--- a/test/com/amazon/ionschema/ResourceAuthorityTest.kt
+++ b/test/com/amazon/ionschema/ResourceAuthorityTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ResourceAuthorityTest {
+
+    @Test
+    fun unknownSchemaId() {
+        val iss = IonSchemaSystemBuilder.standard().build()
+        val authority = ResourceAuthority("ion-schema-schemas", ResourceAuthority::class.java.classLoader)
+        val iter = authority.iteratorFor(iss, "unknown_schema_id")
+        assertFalse(iter.hasNext())
+        try {
+            iter.next()
+            fail()
+        } catch (e: NoSuchElementException) {
+        }
+        iter.close()
+    }
+
+    @Test
+    fun knownSchemaId() {
+        val iss = IonSchemaSystemBuilder.standard().build()
+        val authority = ResourceAuthority("ion-schema-schemas", ResourceAuthority::class.java.classLoader)
+        val iter = authority.iteratorFor(iss, "isl/schema.isl")
+        assertTrue(iter.hasNext())
+        iter.close()
+    }
+
+    @Test
+    fun canLoadIonSchemaSchemas() {
+        val ion = IonSystemBuilder.standard().build()
+        val iss = IonSchemaSystemBuilder.standard()
+            .withIonSystem(ion)
+            .withAuthority(ResourceAuthority.forIonSchemaSchemas())
+            .build()
+        val islSchema = iss.loadSchema("isl/schema.isl")
+
+        assertNotNull("Unable to find the schema for 'schema'", islSchema.getType("schema"))
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**
Fixes #156 

**Description of changes:**
Copies the `ion-schema-schemas` definition of ISL into the `ion-schema-kotlin` build output (as a resource in the jar) so that users of `ion-schema-kotlin` don't need to pull in any other dependency to get the ISL for ISL.

Also adds an Authority for accessing the schemas. The `ResourceAuthority` can load schemas that are bundled as a resource in a jar, and it comes with a static factory method for accessing the ISL for ISL schemas.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
N/A

Note that this goes against the decision in #122 . The rationale for ignoring that precedent now is:
1. The extra size is trivial—the total size of the `ion-schema-kotlin` jar is approximately 266kb (~500kb uncompressed), whereas the ISL schemas (uncompressed and using the ion text encoding) are under 9kb. This represents approximately a 2% increase in the size of the build artifact.
2. The ease-of-use improvement is significant for users of the library. These schemas can be used for static analysis at build time, and we should encourage Ion Schema users to do so as a best practice. It's much easier for users if the schemas are bundled in the jar rather than requiring our users to mount a git submodule.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
