### PR TITLE
Update test names in AbstractTestRunner

### DIFF
--- a/test/com/amazon/ionschema/AbstractTestRunner.kt
+++ b/test/com/amazon/ionschema/AbstractTestRunner.kt
@@ -40,7 +40,7 @@ abstract class AbstractTestRunner(
         test: () -> Unit
     ) {
 
-        val desc = Description.createTestDescription(testName, ion.toString())
+        val desc = Description.createTestDescription("${testClass.simpleName}: $testName", ion.toString())
         try {
             notifier.fireTestStarted(desc)
             test()


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

Adds more detail to the test names in AbstractTestRunner so that when iterating the ion-schema-tests files, the test "class" name will include the subclass of AbstractTestRunner and the name of the test case file.

The purpose of this is to make it easier to read the test results.

Eg. prior to this change, we would get a test report with two different tests named `constraints/all_of/core_types`, now we get `ISLforISLTestRunner: constraints/all_of/core_types` and `IonSchemaTestRunner: constraints/all_of/core_types`

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

N/A

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
