### PR TITLE
Updates the dokka gradle plugin to a stable release version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,13 @@ buildscript {
   }
   dependencies {
     classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
+    classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
   }
 }
 
 plugins {
   id "org.jetbrains.kotlin.jvm" version "1.4.0"
-  id "org.jetbrains.dokka" version "0.9.18"
+  id "org.jetbrains.dokka" version "1.4.32"
   id "maven-publish"
   id "signing"
   id "org.jlleitschuh.gradle.ktlint" version "10.0.0"
@@ -76,19 +77,27 @@ ktlint {
   outputToConsole = true
 }
 
-dokka {
-  outputFormat = "html"
-  outputDirectory = "$buildDir/javadoc"
-  includes = ["src/com/amazon/ionschema/module.md"]
+dokkaJavadoc.configure {
+  dokkaSourceSets {
+    named("main") {
+      includes.from("src/com/amazon/ionschema/module.md")
+      sourceLink {
+        // URL showing where the source code can be accessed through the web browser
+        remoteUrl.set(java.net.URL("https://github.com/amzn/ion-schema-kotlin/blob/master/src"))
+        // Suffix which is used to append the line number to the URL. Use #L for GitHub
+        remoteLineSuffix.set("#L")
+      }
+    }
+  }
 }
 
 task sourcesJar(type: Jar) {
+  classifier 'sources'
   from "src"
-  classifier = "sources"
 }
-task javadocJar(type: Jar) {
-  from dokka
-  classifier = "javadoc"
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+  classifier 'javadoc'
+  from dokkaJavadoc.outputDirectory
 }
 publishing {
   publications {


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

This is an updated fix for https://github.com/amzn/ion-schema-kotlin/issues/130 now that Dokka is stable. It will eliminate the manual steps for generating correct Javadoc in our release process.

I tested this manually when I was publishing the 1.2.0 release, so I can confirm that it works.

*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
