### PR TITLE
Fixes a bug in ResourceAuthority that prevents it from actually loading any resources

### DIFF
--- a/test/com/amazon/ionschema/ResourceAuthorityTest.kt
+++ b/test/com/amazon/ionschema/ResourceAuthorityTest.kt
@@ -48,6 +48,18 @@ class ResourceAuthorityTest {
     }
 
     @Test
+    fun schemaIdOutsideBasePath() {
+        val iss = IonSchemaSystemBuilder.standard().build()
+        val authority = ResourceAuthority("ion-schema-schemas", ResourceAuthority::class.java.classLoader)
+        try {
+            authority.iteratorFor(iss, "../outside_the_base_path")
+            fail()
+        } catch (e: AccessDeniedException) {
+            // Pass
+        }
+    }
+
+    @Test
     fun canLoadIonSchemaSchemas() {
         val ion = IonSystemBuilder.standard().build()
         val iss = IonSchemaSystemBuilder.standard()


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

There is a logic error in the `ResourceAuthority`. When a new instance is initialized, it normalizes the root path to always end with `/`, but when it loads a resources, it always adds another `/` on the end of the root path. This change makes `ResourceAuthority` use the JDK's file related APIs to correctly concatenate the parts of the resource path and then normalize the result. 

This logic error was not detected in unit tests because `foo//bar` and `foo/bar` are considered equivalent paths on *nix file systems, but they are not equivalent paths inside of a zip file (or in our case, a jar). The gradle junit task uses the compiled `.class` files and finds resources in the local file system for running tests rather than having the tests depend on the output of the jar task (probably because it's faster). So the incorrect code worked fine when running the test suite, but it does _not_ work in real use cases where ion-schema-kotlin is a dependency of another package.

I have looked into whether I can change the unit test task so it could catch this in future (by running against the JAR rather than `.classes`) and tried some suggested solutions from SO without any success. However, the way the resource path is handled now isn't as brittle (ie. it properly normalizes paths), so I think it should be okay that I can't replicate the problem in a unit test. For now I have manually tested this change.

This change also adds a check to make sure users aren't trying to access a schema outside of the base path, which is a check that is also performed by `AuthorityFileSystem`.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
N/A

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
