### PR TITLE
Adds check to make sure ISL version marker is valid

### DIFF
--- a/src/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/src/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -61,6 +61,10 @@ internal class SchemaImpl private constructor(
 
     private val declaredTypes: Map<String, TypeImpl>
 
+    companion object {
+        private val ISL_VERSION_MARKER = Regex("^\\\$ion_schema_\\d+_\\d+")
+    }
+
     init {
         val dgIsl = schemaSystem.ionSystem.newDatagram()
 
@@ -74,8 +78,11 @@ internal class SchemaImpl private constructor(
 
                 dgIsl.add(it.clone())
 
-                if (it is IonSymbol && it.stringValue() == "\$ion_schema_1_0") {
-                    // TBD https://github.com/amzn/ion-schema-kotlin/issues/95
+                if (it is IonSymbol && ISL_VERSION_MARKER.matches(it.stringValue())) {
+                    // This implementation only supports Ion Schema 1.0
+                    if (it.stringValue() != "\$ion_schema_1_0") {
+                        throw InvalidSchemaException("Unsupported Ion Schema version: ${it.stringValue()}")
+                    }
                 } else if (it.hasTypeAnnotation("schema_header")) {
                     importsMap = loadHeader(types, it as IonStruct)
                     foundHeader = true

--- a/test/com/amazon/ionschema/SchemaTest.kt
+++ b/test/com/amazon/ionschema/SchemaTest.kt
@@ -33,6 +33,16 @@ class SchemaTest {
         .addAuthority(AuthorityFilesystem("ion-schema-tests"))
         .build()
 
+    @Test(expected = InvalidSchemaException::class)
+    fun invalid_schema_version() {
+        iss.newSchema(
+            """
+            ${'$'}ion_schema_2_0
+            type::{ name: foo, type: int }
+            """.trimIndent()
+        )
+    }
+
     @Test
     fun getType() {
         assertNotNull(iss.loadSchema("schema/Customer.isl").getType("Customer"))


### PR DESCRIPTION
**Issue #, if available:**

#95 


**Description of changes:**

Throws an `InvalidSchemaException` if the schema contains an ISL version marker for a version other than 1.0.

This is _technically_ a breaking change, but it should not be a _substantive_ breaking change since there are no other ISL versions in existence, and no one should be adding ISL version markers other than `$ion_schema_1_0`.

Why are we making this change? Because otherwise, users could start creating schemas with (for example) `$ion_schema_2_0`, and whenever support for `$ion_schema_2_0` is released, there could be unexpected behavior changes for the user's schema.

Also, [according to the spec](https://amzn.github.io/ion-schema/docs/spec.html#schema-definitions), schemas are required to start specifically with `$ion_schema_1_0`. Some of our users—as well as our own test cases—have schemas that _do not_ start with an ISL version marker. It would be a substantive breaking change if we started to enforce the presence of the version marker. Minimally, though, we can start by enforcing that the ISL version marker is for a version that actually exists.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
