### PR TITLE
Adds AST model for ISL

### DIFF
--- a/ion-schema/build.gradle
+++ b/ion-schema/build.gradle
@@ -28,8 +28,10 @@ repositories {
 
 dependencies {
   api "com.amazon.ion:ion-java:[1.4,)"
+  api "com.amazon.ion:ion-element:0.2.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 
 processResources {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstConstraint.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+/**
+ * Represents an Ion Schema Language constraint. Implementations must add any necessary properties for modelling the
+ * details of that particular constraint.
+ *
+ * The recursive type bound enforces that [id] has a valueType that is the same type as the implementation of this interface.
+ *
+ * Sometimes we may need to get a ConstraintId in a static way (i.e. we have no instance of this constraint). For this
+ * reason, it is recommended that all concrete implementations of [AstConstraint] include a companion object like this
+ * example from [AllOfConstraint]:
+ * ```
+ * companion object : ConstraintId<AllOfConstraint> by ConstraintId("all_of") {
+ *     @JvmField val ID = this@Companion
+ * }
+ * ```
+ * The companion object implements [ConstraintId] which means that when using this library from Kotlin, the class
+ * itself is like a static [ConstraintId].
+ * ```
+ * val someId: ConstraintId<*> = AllOfConstraint
+ * ```
+ * When using this library from Java, the ConstraintId can be accessed from `AllOfConstraint.ID`
+ * ```
+ * ConstraintId<?> someId = AllOfConstraint.ID;
+ * ```
+ */
+interface AstConstraint<T : AstConstraint<T>> {
+    val id: ConstraintId<T>
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstFooter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstFooter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.IonElement
+
+/**
+ * Represents the footer of a schema document.
+ */
+data class AstFooter(val additionalContent: Map<String, List<IonElement>> = emptyMap()) {
+    companion object {
+        @JvmField
+        val EMPTY = AstFooter()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstHeader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstHeader.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.IonElement
+
+/**
+ * Represents the header of a schema document.
+ */
+data class AstHeader(val imports: List<Import>, val additionalContent: Map<String, List<IonElement>> = emptyMap()) {
+
+    companion object {
+        @JvmField
+        val EMPTY = AstHeader(emptyList())
+    }
+
+    sealed class Import {
+        /**
+         * Represents an import statement for all types from the given [schemaId].
+         */
+        data class SchemaImport(val schemaId: String) : Import()
+
+        /**
+         * Represents an import statement for a specific [typeId] from the given [schemaId]. The [alias] is the
+         * name by which the type can be referenced in the schema that this header is associated with.
+         */
+        data class TypeImport(val schemaId: String, val typeId: String, val alias: String = typeId) : Import()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstSchema.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstSchema.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.IonElement
+
+/**
+ * Represents a complete Ion Schema document. Note—the model does not include a particular ISL version because the AST
+ * is intended to be a version-agnostic representation of ISL.
+ */
+data class AstSchema(
+    val id: String? = null,
+    val header: AstHeader,
+    val content: List<SchemaContent>,
+    val footer: AstFooter,
+) {
+
+    val types get() = content.filterIsInstance<SchemaContent.NamedType>()
+
+    sealed class SchemaContent {
+        /**
+         * Represents a top-level type declaration in a schema document.
+         */
+        data class NamedType(val name: String, val definition: AstType.TypeDefinition) : SchemaContent() {
+            @JvmOverloads constructor(
+                name: String,
+                constraints: Collection<AstConstraint<*>>,
+                userContent: List<Pair<String, IonElement>> = emptyList()
+            ) : this(
+                name, AstType.TypeDefinition(constraints, userContent)
+            )
+        }
+
+        /**
+         * Represents top-level user content (i.e. "open content") in a schema document.
+         */
+        data class UserContent(private val element: IonElement) : SchemaContent(), IonElement by element
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstType.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstType.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.*
+
+sealed class AstType {
+
+    /**
+     * Represents a named reference to another type. If the [typeId] exists in the scope of the enclosing type (i.e. the
+     * type was imported in the header, declared elsewhere in the same schema document, or is a built-in type), then
+     * [schemaId] can be null. For inline imports, [schemaId] must not be null.
+     */
+    data class TypeReference @JvmOverloads constructor(val typeId: String, val schemaId: String? = null) : AstType()
+
+    /**
+     * Represents a type as defined by a set of constraints, with optional user-provided content (i.e. "open content").
+     */
+    data class TypeDefinition @JvmOverloads constructor(
+        val constraints: Collection<AstConstraint<*>>,
+        val userContent: List<Pair<String, IonElement>> = emptyList()
+    ) : AstType()
+}
+
+/**
+ * Gets all instances of a particular constraint, cast to the correct type for the given [constraintId].
+ */
+operator fun <T : AstConstraint<T>> AstType.TypeDefinition.get(constraintId: ConstraintId<T>): List<T> {
+    // Compiler thinks that this is an unchecked cast, but we know it's safe because the type bound of AstConstraint
+    // and ConstraintId must be the same, and we've already verified that the ID matches.
+    return constraints.filter { it.id == constraintId }.map { it as T }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstVariablyOccurringType.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/AstVariablyOccurringType.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+/**
+ * Represents a type that has an `occurs` value. Note that this includes even
+ * implicit `occurs`, such as in this example:
+ * ```
+ * type::{
+ *   fields: {
+ *     foo: string  // this `string` has an implicit `occurs: optional`
+ *   }
+ * }
+ * ```
+ */
+data class AstVariablyOccurringType(val occurs: DiscreteRange, val type: AstType)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintId.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintId.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+/**
+ * Constraints are uniquely identified by their name (i.e. their ISL keyword). The [valueType] is included so that it is
+ * always possible to safely cast a constraint to the appropriate type, and so that constraint implementations cannot
+ * (easily) use the incorrect name or value type.
+ *
+ * Note—when creating an API, prefer to use [AnyConstraintId] instead of `TypedConstraintId<*>` so that clients of the
+ * API can use members of the [KnownConstraintIds] enum.
+ */
+interface ConstraintId<T : AstConstraint<T>> : AnyConstraintId {
+    override val valueType: Class<out AstConstraint<T>>
+
+    companion object {
+        /**
+         * Factory function for creating instances of [ConstraintId].
+         */
+        @JvmStatic
+        fun <T : AstConstraint<T>> create(constraintName: String, valueType: Class<T>): ConstraintId<T> = ConstraintIdImpl(constraintName, valueType)
+
+        // Kotlin-idiomatic pseudo-constructor. Not callable from Java because of the reified type parameter.
+        inline operator fun <reified T : AstConstraint<T>> invoke(constraintId: String) = create(constraintId, T::class.java)
+    }
+}
+
+private data class ConstraintIdImpl<T : AstConstraint<T>>(override val constraintName: String, override val valueType: Class<T>) : ConstraintId<T>
+
+/**
+ * Use this interface instead of `TypedConstraintId<*>`. This interface exists because it is not allowed for an enum
+ * class to implement a generic interface.
+ *
+ * @see ConstraintId
+ */
+interface AnyConstraintId {
+    val constraintName: String
+    val valueType: Class<out AstConstraint<*>>
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintMediator.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintMediator.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+/**
+ * Interactions between the Ion Schema System and [AstConstraint]s are mediated through ConstraintMediators.
+ *
+ * A ConstraintMediator can hold any kind of data associated to [ConstraintId]s, but it is intended primarily for holding
+ * things such as reader, writer, and validator functions where we need preserve some type information that would
+ * normally be lost through type-erasure.
+ */
+abstract class ConstraintMediator<R : ConstraintMediator.Registration<*>>(private val registrations: List<R>) {
+    /**
+     * Tests whether the mediator contains any registration for the given constraint name.
+     */
+    operator fun contains(name: String): Boolean = registrations.any { it.id.constraintName == name }
+
+    /**
+     * Gets the wild-card-typed registration for the given constraint name.
+     */
+    operator fun get(name: String): R = registrations.single { it.id.constraintName == name }
+
+    /**
+     * Subclasses should use this to implement a function for getting a type-parameterized [Registration] subclass.
+     * For example:
+     * ```
+     * operator fun <C : AstConstraint<C>> get(id: ConstraintId<C>): ConstraintSerdeRegistration<C> {
+     *     return super._get(id) as ConstraintSerdeRegistration<C>
+     * }
+     * ```
+     */
+    protected fun <C : AstConstraint<C>> _get(id: ConstraintId<C>): Registration<C> {
+        // Compiler thinks that this is an unchecked cast, but we know it's safe because the type bound of Registration
+        // and ConstraintId must be the same, and we've already verified that the ID matches.
+        return registrations.single { it.id == id } as Registration<C>
+    }
+
+    interface Registration<T : AstConstraint<T>> {
+        val id: ConstraintId<T>
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintSerdeMediator.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintSerdeMediator.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.*
+
+/**
+ * Why is there a [ConstraintSerdeMediator] and a [ConstraintValidatorMediator] instead of one big mediator?
+ * In theory, the AST should be language-version agnostic, so we want to be able to have 1 [ConstraintValidatorMediator],
+ * and many [ConstraintSerdeMediator]s.
+ */
+class ConstraintSerdeMediator(registrations: List<ConstraintSerdeRegistration<*>>) : ConstraintMediator<ConstraintSerdeRegistration<*>>(registrations) {
+    operator fun <C : AstConstraint<C>> get(id: ConstraintId<C>): ConstraintSerdeRegistration<C> {
+        return super._get(id) as ConstraintSerdeRegistration<C>
+    }
+
+    /**
+     * Writes a single [AstConstraint] to a [StructField]
+     */
+    inline fun <reified T : AstConstraint<T>> writeConstraint(constraint: AstConstraint<T>): StructField {
+        return field(constraint.id.constraintName, this[constraint.id].write(constraint as T))
+    }
+
+    /**
+     * Reads a single [StructField] to produce an [AstConstraint]
+     */
+    fun readConstraint(field: StructField): AstConstraint<*> {
+        return get(field.name).read(field.value)
+    }
+}
+
+class ConstraintSerdeRegistration<T : AstConstraint<T>>(
+    override val id: ConstraintId<T>,
+    val read: (AnyElement) -> T,
+    val write: (T) -> IonElement
+) : ConstraintMediator.Registration<T>
+
+// Example of how the ConstraintMediator can be used to read ISL and construct the AST.
+fun readType(ion: StructElement, serdeMediator: ConstraintSerdeMediator): AstType.TypeDefinition {
+    return AstType.TypeDefinition(
+        constraints = ion.fields
+            .filter { it.name in serdeMediator } // Find the fields that are constraints
+            .map { serdeMediator.readConstraint(it) } // Read the fields as AstConstraint
+            .toSet(),
+        userContent = ion.fields
+            .filterNot { it.name in serdeMediator && it.name == "name" }
+            .map { it.toPair() }
+    )
+}
+
+// Example of how the ConstraintMediator can be used to write ISL from the AST.
+fun writeType(type: AstType.TypeDefinition, serdeMediator: ConstraintSerdeMediator): IonElement {
+    val fields: Iterable<StructField> = type.constraints.map { serdeMediator.writeConstraint(it) } + type.userContent.map { it.toStructField() }
+    return ionStructOf(fields)
+}
+
+// Utility functions for working with StructFields
+fun Pair<String, IonElement>.toStructField() = field(first, second)
+fun StructField.toPair() = name to value

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintValidatorMediator.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConstraintValidatorMediator.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionschema.model.constraints.ByteLengthConstraint
+import com.amazon.ionschema.model.constraints.ContainsConstraint
+
+class ConstraintValidatorMediator(registrations: List<ConstraintValidatorRegistration<*>>) : ConstraintMediator<ConstraintValidatorRegistration<*>>(registrations) {
+    private operator fun <C : AstConstraint<C>> get(id: ConstraintId<C>): ConstraintValidatorRegistration<C> {
+        return super._get(id) as ConstraintValidatorRegistration<C>
+    }
+
+    /**
+     * Validates an IonElement against a single constraint
+     */
+    inline fun <reified T : AstConstraint<T>> validateConstraint(constraint: AstConstraint<T>, data: IonElement): Boolean {
+        return validateConstraint(constraint as T, data.asAnyElement())
+    }
+
+    fun <T : AstConstraint<T>> validateConstraint(constraint: T, data: AnyElement): Boolean =
+        this[constraint.id].validate(constraint, data)
+}
+
+class ConstraintValidatorRegistration<T : AstConstraint<T>>(
+    override val id: ConstraintId<T>,
+    val validate: (T, AnyElement) -> Boolean
+) : ConstraintMediator.Registration<T>
+
+infix fun <T : AstConstraint<T>> ConstraintId<T>.uses(validate: (T, AnyElement) -> Boolean) =
+    ConstraintValidatorRegistration(this, validate)
+
+val validators = ConstraintValidatorMediator(
+    listOf(
+        ByteLengthConstraint uses { constraint, data -> data.bytesValue.size() in constraint.range },
+        ContainsConstraint uses { constraint, data -> data.containerValues.containsAll(constraint.values) }
+    )
+)
+
+// Example of how the ConstraintMediator can be used to validate data against an AST type.
+fun validateType(type: AstType.TypeDefinition, data: IonElement, mediator: ConstraintValidatorMediator): Boolean {
+    // Note that for simplicity, this example uses a boolean return instead of collecting violations.
+    return type.constraints.all { mediator.validateConstraint(it, data.asAnyElement()) }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteRange.kt
@@ -1,0 +1,19 @@
+package com.amazon.ionschema.model
+
+/**
+ * Represents a value that can be an integer or an integer range.
+ * Example usage—modelling container length, decimal precision, etc.
+ */
+class DiscreteRange internal constructor(private val delegate: RangeDelegate<Int>) : Range<Int> by delegate {
+    constructor(min: Min, max: Int) : this(RangeDelegate(min, max))
+    constructor(min: Int, max: Int) : this(RangeDelegate(min, max))
+    constructor(min: Int, max: Max) : this(RangeDelegate(min, max))
+
+    init {
+        if (delegate.min is Int && delegate.max is Int) require(delegate.min <= delegate.max)
+    }
+
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun equals(other: Any?): Boolean = other is DiscreteRange && delegate == other.delegate
+    override fun toString(): String = "DiscreteRange(min=$min,max=$max)"
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Isl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Isl.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+@file:JvmName("IonSchemaBuilders")
+package com.amazon.ionschema.model
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionschema.model.constraints.*
+import java.math.BigDecimal
+
+// This file contains a straw-man example of a dsl for creating Ion Schemas.
+// Ideally, this would be exposed as java builders and a kotlin type-safe DSL, like
+// the ones in the AWS Kotlin SDK.
+//
+// At the bottom of this file, you can find an example of programmatically constructing the
+// types found at https://amzn.github.io/ion-schema/docs/spec.html#customer-profile-data
+
+fun inline(vararg constraints: AstConstraint<*>) = AstType.TypeDefinition(constraints.toList())
+fun inline(vararg constraints: AstConstraint<*>, occurs: DiscreteRange) = AstVariablyOccurringType(occurs, inline(*constraints))
+fun named(typeId: String) = AstType.TypeReference(typeId)
+fun named(typeId: String, occurs: DiscreteRange) = AstVariablyOccurringType(occurs, named(typeId))
+fun import(schemaId: String, typeId: String) = AstType.TypeReference(typeId, schemaId)
+fun import(occurs: DiscreteRange, schemaId: String, typeId: String) = AstVariablyOccurringType(occurs, AstType.TypeReference(typeId, schemaId))
+
+// Constraints
+fun allOf(vararg types: AstType) = AllOfConstraint(types.toList())
+fun allOf(types: Iterable<AstType>) = AllOfConstraint(types)
+fun annotations(type: AstType) = AnnotationsConstraint(type)
+fun anyOf(vararg types: AstType) = AnyOfConstraint(types.toList())
+fun anyOf(types: Iterable<AstType>) = AnyOfConstraint(types)
+fun byteLength(range: DiscreteRange) = ByteLengthConstraint(range)
+fun byteLength(value: Int) = ByteLengthConstraint(DiscreteRange(value, value))
+fun codepointLength(range: DiscreteRange) = CodepointLengthConstraint(range)
+fun codepointLength(value: Int) = CodepointLengthConstraint(DiscreteRange(value, value))
+fun containerLength(range: DiscreteRange) = ContainerLengthConstraint(range)
+fun containerLength(value: Int) = ContainerLengthConstraint(DiscreteRange(value, value))
+fun contains(vararg values: IonElement) = ContainsConstraint(values.toList())
+fun contains(values: Collection<IonElement>) = ContainsConstraint(values)
+fun element(type: AstType) = ElementConstraint(type)
+fun fields(vararg fields: Pair<String, AstVariablyOccurringType>) = FieldsConstraint(fields.toMap())
+fun fields(fields: Map<String, AstVariablyOccurringType>) = FieldsConstraint(fields)
+fun not(type: AstType) = NotConstraint(type)
+fun oneOf(vararg types: AstType) = OneOfConstraint(types.toList())
+fun oneOf(types: Iterable<AstType>) = OneOfConstraint(types)
+fun orderedElements(vararg types: AstVariablyOccurringType) = OrderedElementsConstraint(types.toList())
+fun orderedElements(types: Iterable<AstVariablyOccurringType>) = OrderedElementsConstraint(types)
+fun precision(range: DiscreteRange) = PrecisionConstraint(range)
+fun precision(value: Int) = PrecisionConstraint(DiscreteRange(value, value))
+fun regex(pattern: String, options: Set<RegexConstraint.Options>) = RegexConstraint(pattern, options)
+fun regex(pattern: String, vararg options: RegexConstraint.Options) = RegexConstraint(pattern, options.toSet())
+fun scale(range: DiscreteRange) = ScaleConstraint(range)
+fun scale(value: Int) = ScaleConstraint(DiscreteRange(value, value))
+fun timestampPrecision(range: TimestampPrecisionRange) = TimestampPrecisionConstraint(range)
+fun timestampPrecision(value: TimestampPrecisions) = TimestampPrecisionConstraint(TimestampPrecisionRange(value, value))
+fun timestampOffset(offset: TimestampOffsetConstraint.Offset) = TimestampOffsetConstraint(offset)
+fun timestampOffset(hours: Int, minutes: Int = 0) = TimestampOffsetConstraint(TimestampOffsetConstraint.Offset.Minutes(hours * 60 + minutes))
+fun timestampOffset(minutes: Int) = TimestampOffsetConstraint(TimestampOffsetConstraint.Offset.Minutes(minutes))
+fun type(type: AstType) = TypeConstraint(type)
+fun utf8ByteLength(range: DiscreteRange) = Utf8ByteLengthConstraint(range)
+fun utf8ByteLength(value: Int) = Utf8ByteLengthConstraint(DiscreteRange(value, value))
+fun validValues(values: Iterable<ValidValue>) = ValidValuesConstraint(values)
+fun validValues(vararg values: ValidValue) = ValidValuesConstraint(values.toList())
+fun validValues(vararg ionValues: IonElement) = ValidValuesConstraint(ionValues.map { ValidValue.SingleValue(it) })
+
+// Ranges
+fun range(min: Int, max: Int) = DiscreteRange(min, max)
+fun atLeast(min: Int) = DiscreteRange(min, Max)
+fun atMost(max: Int) = DiscreteRange(Min, max)
+fun exactly(n: Int) = DiscreteRange(n, n)
+
+// Syntactical sugar
+fun nullOr(type: AstType): AstType = inline(anyOf(type, named("\$null")))
+fun literal(element: IonElement) = inline(validValues(element))
+
+fun optional(type: AstType) = type.occurs(range(0, 1))
+fun required(type: AstType) = type.occurs(exactly(1))
+fun AstType.occurs(range: DiscreteRange) = AstVariablyOccurringType(range, this)
+
+// ISL 1.0-ish syntax for annotations
+fun annotations(vararg annotationSymbols: CharSequence, closed: Boolean = false, required: Boolean = false): AnnotationsConstraint {
+    // TODO: make sure this is correct
+    val constraints = mutableListOf<AstConstraint<*>>()
+    if (closed) {
+        val annotationSymbolValues = annotationSymbols.map {
+            ValidValue.SingleValue(ionSymbol(it.toString()))
+        }
+        constraints.add(element(inline(validValues(annotationSymbolValues))))
+    }
+    val requiredSymbols = if (required) {
+        annotationSymbols.filter { it !is OptionalAnnotation }.map { ionSymbol(it.toString()) }
+    } else {
+        annotationSymbols.filterIsInstance<RequiredAnnotation>().map { ionSymbol(it.toString()) }
+    }
+    if (requiredSymbols.isNotEmpty()) {
+        constraints.add(contains(requiredSymbols))
+    }
+
+    return AnnotationsConstraint(AstType.TypeDefinition(constraints.toList()))
+}
+internal class RequiredAnnotation(val s: String) : CharSequence by s
+internal class OptionalAnnotation(val s: String) : CharSequence by s
+fun required(s: String): CharSequence = RequiredAnnotation(s)
+fun optional(s: String): CharSequence = OptionalAnnotation(s)
+
+
+// Example usage:
+val shortStringType = AstSchema.SchemaContent.NamedType(
+    name = "short_string",
+    constraints = listOf(
+        type(named("string")),
+        codepointLength(atMost(50))
+    )
+)
+
+val stateType = AstSchema.SchemaContent.NamedType(
+    name = "State",
+    constraints = listOf(
+        validValues(
+            """
+                AK, AL, AR, AZ, CA, CO, CT, DE, FL, GA, HI, IA, ID, IL, IN, KS, KY,
+                LA, MA, MD, ME, MI, MN, MO, MS, MT, NC, ND, NE, NH, NJ, NM, NV, NY,
+                OH, OK, OR, PA, RI, SC, SD, TN, TX, UT, VA, VT, WA, WI, WV, WY
+            """.split(",").map { ValidValue.SingleValue(ionSymbol(it.trim())) }
+        )
+    )
+)
+
+val addressType = AstSchema.SchemaContent.NamedType(
+    name = "Address",
+    constraints = listOf(
+        type(named("struct")),
+        fields(
+            "address1" to inline(
+                type(named(shortStringType.name)),
+                occurs = exactly(1)
+            ),
+            "address2" to inline(
+                type(named(shortStringType.name)),
+                occurs = range(0, 1)
+            ),
+            "city" to inline(
+                type(named("string")),
+                codepointLength(range(0, 20)),
+                occurs = exactly(1)
+            ),
+            "state" to inline(
+                type(named(stateType.name)),
+                occurs = exactly(1)
+            ),
+            "zipcode" to inline(
+                type(named("int")),
+                validValues(
+                    ValidValue.NumberRange(BigDecimal.valueOf(10000), BigDecimal.valueOf(99999))
+                ),
+                occurs = exactly(1)
+            ),
+        )
+    )
+)
+
+val customerType = AstSchema.SchemaContent.NamedType(
+    name = "Customer",
+    constraints = listOf(
+        type(named("struct")),
+        annotations("corporate", "gold_class", "club_member"),
+        fields(
+            "firstName" to named("string").occurs(exactly(1)),
+            "middleName" to nullOr(named("\$string")).occurs(range(0, 1)),
+            "lastName" to named("string").occurs(exactly(1)),
+            "customerId" to inline(
+                oneOf(
+                    inline(
+                        type(named("string")),
+                        codepointLength(exactly(18))
+                    ),
+                    inline(
+                        type(named("int")),
+                        validValues(
+                            ValidValue.NumberRange(BigDecimal.valueOf(100000), BigDecimal.valueOf(999999))
+                        ),
+                    )
+                ),
+                occurs = exactly(1)
+            ),
+            "addresses" to inline(
+                type(named("list")),
+                element(named(addressType.name)),
+                containerLength(range(1, 7)),
+                occurs = exactly(1)
+            ),
+            "lastUpdated" to inline(
+                type(named("timestamp")),
+                timestampPrecision(TimestampPrecisionRange(TimestampPrecisions.Second, TimestampPrecisions.Millisecond)),
+                occurs = exactly(1)
+            )
+        )
+    )
+)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/KnownConstraintIds.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/KnownConstraintIds.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+import com.amazon.ionschema.model.constraints.*
+
+/**
+ * An enumeration of all known (ie. built-in) [ConstraintId]s.
+ */
+enum class KnownConstraintIds(id: AnyConstraintId) : AnyConstraintId by id {
+    AllOf(AllOfConstraint),
+    Annotations(AnnotationsConstraint),
+    AnyOf(AnyOfConstraint),
+    ByteLength(ByteLengthConstraint),
+    CodepointLength(CodepointLengthConstraint),
+    ContainerLength(ContainerLengthConstraint),
+    Contains(ContainsConstraint),
+    Element(ElementConstraint),
+    Fields(FieldsConstraint),
+    Not(NotConstraint),
+    OneOf(OneOfConstraint),
+    OrderedElements(OrderedElementsConstraint),
+    Precision(PrecisionConstraint),
+    Regex(RegexConstraint),
+    Scale(ScaleConstraint),
+    TimestampOffset(TimestampOffsetConstraint),
+    TimestampPrecision(TimestampPrecisionConstraint),
+    Type(TypeConstraint),
+    Utf8ByteLength(Utf8ByteLengthConstraint),
+    ValidValues(ValidValuesConstraint);
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Range.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Range.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model
+
+/**
+ * Set of tools for creating a variety of implementations of ranges.
+ *
+ * * Endpoints of the range do not need to be `T`—just comparable to `T`.
+ * * Endpoints of the range can be open (exclusive) or closed (inclusive) using [Boundary].
+ * * Ranges can be bounded, left bounded, or right bounded. See [Min] and [Max].
+ *
+ */
+interface Range<T : Comparable<T>> {
+    val min: Comparable<T>
+    val max: Comparable<T>
+    operator fun contains(value: T): Boolean
+}
+
+internal class RangeDelegate<T : Comparable<T>>(
+    override val min: Comparable<T>,
+    override val max: Comparable<T>,
+) : Range<T> {
+
+    override operator fun contains(value: T): Boolean {
+        val inLower = if (min is Value && min.exclusive) min < value else min <= value
+        val inUpper = if (max is Value && max.exclusive) max > value else max >= value
+        return inLower && inUpper
+    }
+
+    override fun hashCode(): Int = min.hashCode() + 31 * max.hashCode()
+    override fun equals(other: Any?): Boolean = other is Range<*> && this.min == other.min && this.max == other.max
+}
+
+sealed class Boundary<T> : Comparable<T>
+
+/**
+ * Special value that can be compared to anything and that is always greater than the other value.
+ */
+object Max : Boundary<Any>(), Comparable<Any> {
+    override fun compareTo(other: Any): Int = 1
+    override fun toString(): String = "Max"
+}
+
+/**
+ * Special value that can be compared to anything and that is always less than the other value.
+ */
+object Min : Boundary<Any>(), Comparable<Any> {
+    override fun compareTo(other: Any): Int = -1
+    override fun toString(): String = "Min"
+}
+
+/**
+ * A wrapper for endpoint values that allows us to create exclusive endpoints.
+ */
+class Value<T : Comparable<T>>(val value: T, val exclusive: Boolean = false) : Comparable<T> by value, Boundary<T>()

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AllOfConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AllOfConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class AllOfConstraint(override val types: Iterable<AstType>) : NAryTypeConstraint<AllOfConstraint> {
+    companion object : ConstraintId<AllOfConstraint> by ConstraintId("all_of") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AnnotationsConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AnnotationsConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class AnnotationsConstraint(override val type: AstType) : UnaryTypeConstraint<AnnotationsConstraint> {
+    companion object : ConstraintId<AnnotationsConstraint> by ConstraintId("annotations") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AnyOfConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/AnyOfConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class AnyOfConstraint(override val types: Iterable<AstType>) : NAryTypeConstraint<AnyOfConstraint> {
+    companion object : ConstraintId<AnyOfConstraint> by ConstraintId("any_of") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ByteLengthConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ByteLengthConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class ByteLengthConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<ByteLengthConstraint> {
+    companion object : ConstraintId<ByteLengthConstraint> by ConstraintId("byte_length") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/CodepointLengthConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/CodepointLengthConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class CodepointLengthConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<CodepointLengthConstraint> {
+    companion object : ConstraintId<CodepointLengthConstraint> by ConstraintId("codepoint_length") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Constraints.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Constraints.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.DiscreteRange
+
+/**
+ * Common interface for constraints that have range over discrete integers as their only argument.
+ * This allows for code reuse when reading, writing, and validating the `scale`, `precision`, and `*_length` constraints.
+ */
+interface DiscreteRangeConstraint<T> : AstConstraint<T> where T : AstConstraint<T>, T : DiscreteRangeConstraint<T> {
+    val range: DiscreteRange
+}
+
+/**
+ * Common interface for constraints that have a single type as their argument.
+ * This allows for code reuse when reading and writing the `element`, `not`, and `type` constraints.
+ */
+interface UnaryTypeConstraint<T> : AstConstraint<T> where T : AstConstraint<T>, T : UnaryTypeConstraint<T> {
+    val type: AstType
+}
+
+/**
+ * Common interface for constraints that have a list of N types as their only argument.
+ * This allows for code reuse when reading and writing the`any_of`, `all_of`, and `one_of` constraints.
+ */
+interface NAryTypeConstraint<T> : AstConstraint<T> where T : AstConstraint<T>, T : NAryTypeConstraint<T> {
+    val types: Iterable<AstType>
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Constraints.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Constraints.kt
@@ -36,7 +36,7 @@ interface UnaryTypeConstraint<T> : AstConstraint<T> where T : AstConstraint<T>, 
 
 /**
  * Common interface for constraints that have a list of N types as their only argument.
- * This allows for code reuse when reading and writing the`any_of`, `all_of`, and `one_of` constraints.
+ * This allows for code reuse when reading and writing the `any_of`, `all_of`, and `one_of` constraints.
  */
 interface NAryTypeConstraint<T> : AstConstraint<T> where T : AstConstraint<T>, T : NAryTypeConstraint<T> {
     val types: Iterable<AstType>

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ContainerLengthConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ContainerLengthConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class ContainerLengthConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<ContainerLengthConstraint> {
+    companion object : ConstraintId<ContainerLengthConstraint> by ConstraintId("container_length") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ContainsConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ContainsConstraint.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.ConstraintId
+
+data class ContainsConstraint(val values: Collection<IonElement>) : AstConstraint<ContainsConstraint> {
+    companion object : ConstraintId<ContainsConstraint> by ConstraintId("contains") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ElementConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ElementConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class ElementConstraint(override val type: AstType) : UnaryTypeConstraint<ElementConstraint> {
+    companion object : ConstraintId<ElementConstraint> by ConstraintId("element") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/FieldsConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/FieldsConstraint.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.AstVariablyOccurringType
+import com.amazon.ionschema.model.ConstraintId
+
+data class FieldsConstraint(val fields: Map<String, AstVariablyOccurringType>, val closed: Boolean = false) : AstConstraint<FieldsConstraint> {
+    companion object : ConstraintId<FieldsConstraint> by ConstraintId("fields") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/NotConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/NotConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class NotConstraint(override val type: AstType) : UnaryTypeConstraint<NotConstraint> {
+    companion object : ConstraintId<NotConstraint> by ConstraintId("not") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/OneOfConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/OneOfConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class OneOfConstraint(override val types: Iterable<AstType>) : NAryTypeConstraint<OneOfConstraint> {
+    companion object : ConstraintId<OneOfConstraint> by ConstraintId("one_of") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/OrderedElementsConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/OrderedElementsConstraint.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.AstVariablyOccurringType
+import com.amazon.ionschema.model.ConstraintId
+
+data class OrderedElementsConstraint(val types: Iterable<AstVariablyOccurringType>) :
+    AstConstraint<OrderedElementsConstraint> {
+    companion object : ConstraintId<OrderedElementsConstraint> by ConstraintId("ordered_elements") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/PrecisionConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/PrecisionConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class PrecisionConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<PrecisionConstraint> {
+    companion object : ConstraintId<PrecisionConstraint> by ConstraintId("precision") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/RegexConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/RegexConstraint.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.ConstraintId
+
+data class RegexConstraint constructor(val pattern: String, val options: Set<Options>) : AstConstraint<RegexConstraint> {
+    companion object : ConstraintId<RegexConstraint> by ConstraintId("regex") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+
+    init {
+        // Validate the regex pattern
+    }
+
+    val regex by lazy { Regex(pattern, options = options.map { it.regexOption }.toSet()) }
+
+    enum class Options(internal val regexOption: RegexOption) {
+        MULTILINE(RegexOption.MULTILINE),
+        IGNORE_CASE(RegexOption.IGNORE_CASE);
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ScaleConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ScaleConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class ScaleConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<ScaleConstraint> {
+    companion object : ConstraintId<ScaleConstraint> by ConstraintId("scale") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TimestampOffsetConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TimestampOffsetConstraint.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstConstraint
+import com.amazon.ionschema.model.ConstraintId
+
+data class TimestampOffsetConstraint(val offset: Offset) : AstConstraint<TimestampOffsetConstraint> {
+    companion object : ConstraintId<TimestampOffsetConstraint> by ConstraintId("timestamp_offset") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+    sealed class Offset {
+        object Unknown : Offset()
+        data class Minutes(val minutes: Int) : Offset()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TimestampPrecisionConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TimestampPrecisionConstraint.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.*
+
+data class TimestampPrecisionConstraint(val range: TimestampPrecisionRange) : AstConstraint<TimestampPrecisionConstraint> {
+    companion object : ConstraintId<TimestampPrecisionConstraint> by ConstraintId("timestamp_precision") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}
+
+class TimestampPrecisionRange private constructor(private val delegate: RangeDelegate<TimestampPrecisions>) : Range<TimestampPrecisions> by delegate {
+    constructor(min: Min, max: TimestampPrecisions) : this(RangeDelegate(min, max))
+    constructor(min: TimestampPrecisions, max: TimestampPrecisions) : this(RangeDelegate(min, max))
+    constructor(min: TimestampPrecisions, max: Max) : this(RangeDelegate(min, max))
+
+    init {
+        if (delegate.min is TimestampPrecisions && delegate.max is TimestampPrecisions) require(delegate.min <= delegate.max)
+    }
+
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun equals(other: Any?): Boolean = other is TimestampPrecisionRange && delegate == other.delegate
+    override fun toString(): String = "TimestampPrecisionRange(min=$min,max=$max)"
+}
+
+enum class TimestampPrecisions {
+    Year,
+    Month,
+    Day,
+    Minute,
+    Second,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TypeConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/TypeConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.AstType
+import com.amazon.ionschema.model.ConstraintId
+
+data class TypeConstraint(override val type: AstType) : UnaryTypeConstraint<TypeConstraint> {
+    companion object : ConstraintId<TypeConstraint> by ConstraintId("type") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Utf8ByteLengthConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/Utf8ByteLengthConstraint.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionschema.model.ConstraintId
+import com.amazon.ionschema.model.DiscreteRange
+
+data class Utf8ByteLengthConstraint(override val range: DiscreteRange) : DiscreteRangeConstraint<Utf8ByteLengthConstraint> {
+    companion object : ConstraintId<Utf8ByteLengthConstraint> by ConstraintId("utf8_byte_length") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ValidValuesConstraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/constraints/ValidValuesConstraint.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.ionschema.model.constraints
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionschema.model.*
+import java.math.BigDecimal
+import java.time.Instant
+
+data class ValidValuesConstraint(val values: Iterable<ValidValue>) : AstConstraint<ValidValuesConstraint> {
+    companion object : ConstraintId<ValidValuesConstraint> by ConstraintId("valid_values") {
+        @JvmField val ID = this@Companion
+    }
+    override val id get() = ID
+}
+
+sealed class ValidValue {
+    data class SingleValue(val value: IonElement) : ValidValue() {
+        init { require(value.annotations.isEmpty()) }
+    }
+    class TimestampRange private constructor(private val delegate: RangeDelegate<Instant>) : ValidValue(), Range<Instant> by delegate {
+        constructor(min: Boundary<Instant>, max: Boundary<Instant>) : this(RangeDelegate(min, max))
+        constructor(min: Instant, max: Boundary<Instant>) : this(RangeDelegate(min, max))
+        constructor(min: Boundary<Instant>, max: Instant) : this(RangeDelegate(min, max))
+        constructor(min: Instant, max: Instant) : this(RangeDelegate(min, max))
+
+        override fun hashCode(): Int = delegate.hashCode()
+        override fun equals(other: Any?): Boolean = other is TimestampRange && delegate == other.delegate
+        override fun toString(): String = "TimestampRange(min=$min,max=$max)"
+    }
+    class NumberRange private constructor(private val delegate: RangeDelegate<BigDecimal>) : ValidValue(), Range<BigDecimal> by delegate {
+        constructor(min: Boundary<BigDecimal>, max: Boundary<BigDecimal>) : this(RangeDelegate(min, max))
+        constructor(min: BigDecimal, max: Boundary<BigDecimal>) : this(RangeDelegate(min, max))
+        constructor(min: Boundary<BigDecimal>, max: BigDecimal) : this(RangeDelegate(min, max))
+        constructor(min: BigDecimal, max: BigDecimal) : this(RangeDelegate(min, max))
+
+        override fun hashCode(): Int = delegate.hashCode()
+        override fun equals(other: Any?): Boolean = other is NumberRange && delegate == other.delegate
+        override fun toString(): String = "NumberRange(min=$min,max=$max)"
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Adds an AST model for Ion Schema.

This PR is intended for initial feedback. There are some examples that are not intended to be merged as is (the mediators and the pseudo-DSL for constructing ISL), and this code admittedly could use a little more thought about the organization. There are also some places where the AST could be improved by using sealed interfaces, but I think I need to update the Kotlin version for that.

Here are a few things I was trying to accomplish:
* Constraints can be identified by ID (essentially the field name, but a little safer since it doesn't rely on hard-coding strings everywhere, and it includes some type information)
* Constraints can also be tested by using `foo is ValidValuesConstraint` (or `foo instanceOf ValidValuesConstraint` in Java), but there is no guarantee that the classes will uniquely identify the constraint.
* The AST classes should (as much as possible) be plain old data objects.
* Prefer composition rather than inheritance. You see this, for example, in `AstVariablyOccuringType` where rather than extending `AstType`, it is composed of an `AstType` member and an occurs range member.
* Where there is redundancy in ISL, express that through convenience functions rather than redundant data structures. For example, the `container_length` constraint can accept a number or a range. I've modeled it as only a range since the a single number `n` is equivalent to `range::[n, n]`.


I've added a few comments denoted by a 📝.

The build is failing because of `ktlint`. This is (somewhat) intentional—I don't care about those failures right now because I don't want this PR to be merged.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
N/A

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
