### PR TITLE
Fix implementation of `ordered_elements`

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
@@ -17,6 +17,22 @@ package com.amazon.ionschema.internal.constraint
 
 /**
  * A Non-deterministic Finite-State Automaton for evaluating regular languages (and analogues thereof).
+ *
+ * This implementation uses the following algorithm.
+ * > the NFA consumes a string of input symbols, one by one. In each step, whenever two or more transitions are applicable,
+ * > it "clones" itself into appropriately many copies, each one following a different transition. If no transition is
+ * > applicable, the current copy is in a dead end, and it "dies". If, after consuming the complete input, any of the
+ * > copies is in an accept state, the input is accepted, else, it is rejected.
+ *
+ * See [Nondeterministic finite automaton](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton).
+ *
+ * This implementation is designed to track which state(s) are visited as well as how many consecutive visits have been
+ * made to any given state. This specialization is intended to make it easier to support cases where an event could occur
+ * a variable number of times (eg. regex `a{2,4}`).
+ *
+ * This implementation does not check for matches that are less than the full stream of events.
+ *
+ * For an example of how to model things using this class, see [OrderedElementsNfaStatesBuilder].
  */
 internal class NFA<Event : Any>(
     /**

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+/**
+ * A Non-deterministic Finite-State Automaton for evaluating regular languages (and analogues thereof).
+ */
+internal class NFA<Event : Any>(
+    /**
+     * An adjacency list describing the transitions between states in the NFA. The adjacency list is modeled as a map of
+     * source to list of destinations. Any intermediate state that appears as a destination must also appear as a key in
+     * the map. The map must contain [NFA.State.Initial] as a key. There may be no transitions out of [NFA.State.Final].
+     */
+    private val transitions: Map<State<Event>, Set<State<Event>>>,
+) {
+
+    init {
+        require(!transitions[State.Initial].isNullOrEmpty()) { "Invalid graph: no transition from initial state." }
+        require(transitions[State.Final].isNullOrEmpty()) { "Invalid graph: no transitions allowed from final state." }
+        transitions.values.flatten().let { destinations ->
+            val unknownDestinations = destinations.filter { it !in transitions.keys && it != State.Final }.distinct()
+            require(unknownDestinations.isEmpty()) { "Invalid graph: transitions to unknown states: $unknownDestinations" }
+            require(State.Final in destinations) { "Invalid graph: no transition to final state." }
+        }
+    }
+
+    companion object { private val END_OF_STREAM_EVENT: Nothing? = null }
+    private val INITIAL_STATE = setOf(StateVisitCount<Event>(State.Initial, 1))
+
+    sealed class State<in Event : Any>(val debugId: String) {
+        open fun canEnter(event: Event?): Boolean = false
+        open fun canReenter(visits: Int): Boolean = false
+        open fun canExit(visits: Int): Boolean = false
+        final override fun toString(): String = debugId
+
+        object Initial : State<Any>("I") {
+            override fun canExit(visits: Int): Boolean = true
+        }
+
+        object Final : State<Any>("F") {
+            override fun canEnter(event: Any?): Boolean = event == END_OF_STREAM_EVENT
+        }
+
+        class Intermediate<Event : Any>(
+            /** Unique identifier for this state. */
+            val id: Int,
+            /** Condition on the [Event] value for entering this state. */
+            val entryCondition: (Event) -> Boolean,
+            /** Condition on number of visits for re-entering this state. Only applies on a loop (i.e. not S1->S2->S1). */
+            val reentryCondition: (Int) -> Boolean,
+            /** Condition on number of visits for leaving this state. Does not apply when following a loop (ie. S1->S1). */
+            val exitCondition: (Int) -> Boolean,
+        ) : State<Event>("S$id") {
+
+            override fun canEnter(event: Event?): Boolean = event != null && entryCondition(event)
+            override fun canReenter(visits: Int): Boolean = reentryCondition(visits)
+            override fun canExit(visits: Int): Boolean = exitCondition(visits)
+
+            override fun hashCode(): Int = id.hashCode()
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                return other is Intermediate<*> && id == other.id
+            }
+        }
+    }
+
+    /** Models the number of times a given state has been visited for a possible path of execution */
+    private data class StateVisitCount<in Event : Any>(val state: State<Event>, val visits: Int) {
+        override fun toString(): String = "${state.debugId}:$visits"
+    }
+
+    private fun Set<StateVisitCount<Event>>.transition(event: Event?, eventDebugString: String? = null): Set<StateVisitCount<Event>> {
+        val newStates = mutableSetOf<StateVisitCount<Event>>()
+
+        // Cache the results of testing the entry conditions for states so that we aren't duplicating any work.
+        val entryConditionCache = mutableMapOf<State<Event>, Boolean>()
+
+        this@transition.forEach { (transitionFromState, visits) ->
+            // Cache the result of canExit, just in case someone has an expensive test here.
+            val canExit = transitionFromState.canExit(visits)
+
+            transitions[transitionFromState]?.forEach { transitionToState ->
+                if (transitionFromState == transitionToState) {
+                    if (transitionToState.canReenter(visits + 1)) {
+                        // Can we enter this same state one more time?
+                        val canEnter = entryConditionCache.getOrPut(transitionToState) { transitionToState.canEnter(event) }
+                        if (canEnter) newStates.add(StateVisitCount(transitionToState, visits + 1))
+                    }
+                } else if (canExit) {
+                    // Can we exit the current state yet, and if so, can we enter the "to" state?
+                    val canEnter = entryConditionCache.getOrPut(transitionToState) { transitionToState.canEnter(event) }
+                    if (canEnter) newStates.add(StateVisitCount(transitionToState, 1))
+                }
+            }
+        }
+        eventDebugString?.let { println("${it.padStart(4)} : $newStates") }
+        return newStates.toSet()
+    }
+
+    /**
+     * Tests if a stream of [Event] is recognized by this state machine.
+     */
+    fun matches(events: Iterable<Event>, debug: Boolean = false): Boolean {
+        if (debug) {
+            println()
+            println(transitions.entries.joinToString("\n") { (k, v) -> "${"$k".padEnd(3)} -> $v" })
+            println("Transitions for input: $events")
+            println("     : $INITIAL_STATE")
+        }
+        return events.foldIndexed(INITIAL_STATE) { idx, states, event -> states.transition(event, if (debug) "$idx" else null) }
+            .transition(END_OF_STREAM_EVENT, if (debug) "END" else null)
+            .any { (state, _) -> state == State.Final }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
@@ -16,7 +16,7 @@
 package com.amazon.ionschema.internal.constraint
 
 /**
- * A Non-deterministic Finite-State Automaton for evaluating regular languages (and analogues thereof).
+ * An approximation of a Non-deterministic Finite-State Automaton for evaluating regular languages (and analogues thereof).
  *
  * This implementation uses the following algorithm.
  * > the NFA consumes a string of input symbols, one by one. In each step, whenever two or more transitions are applicable,

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
@@ -55,8 +55,13 @@ internal class OrderedElements(
     }
 
     override fun validate(value: IonValue, issues: Violations) {
+        validate(value, issues, debug = false)
+    }
+
+    // Visible for testing
+    internal fun validate(value: IonValue, issues: Violations, debug: Boolean) {
         validateAs<IonSequence>(value, issues) { v ->
-            if (!nfa.matches(v)) {
+            if (!nfa.matches(v, debug)) {
                 issues.add(
                     Violation(
                         ion, "ordered_elements_mismatch",

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsNfaStatesBuilder.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsNfaStatesBuilder.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ion.IonValue
+
+/**
+ * Builds a NFA for the `ordered_elements` constraint
+ */
+internal class OrderedElementsNfaStatesBuilder {
+
+    private val stateInputs = mutableListOf<NFA.State<IonValue>>(NFA.State.Initial)
+
+    fun addState(min: Comparable<Int>, max: Comparable<Int>, matches: (IonValue) -> Boolean): OrderedElementsNfaStatesBuilder {
+        val nfaState = NFA.State.Intermediate(
+            id = stateInputs.size,
+            entryCondition = { event: IonValue -> matches(event) },
+            reentryCondition = { visits -> max >= visits },
+            exitCondition = { visits -> min <= visits }
+        )
+        stateInputs.add(nfaState)
+        return this
+    }
+
+    fun build(): Map<NFA.State<IonValue>, Set<NFA.State<IonValue>>> {
+        val states = stateInputs + NFA.State.Final
+
+        val transitions = states.mapIndexed { i, stateI ->
+            val transitionsForStateI = mutableSetOf<NFA.State<IonValue>>()
+
+            // Loop back to self, if max is >= 2
+            if (stateI.canReenter(2)) transitionsForStateI += stateI
+
+            // Add transitions forward up to (including) the first type with a min occurs that is greater than 0
+            var j = i + 1
+            while (j < states.size) {
+                val stateJ = states[j]
+                transitionsForStateI += stateJ
+                // Hack to check if the state is optional. It's safe to do this because the construction of the canExit
+                // condition is also controlled by this class.
+                if (!stateJ.canExit(0)) break
+                j++
+            }
+            stateI to transitionsForStateI.toSet()
+        }
+
+        return transitions.toMap()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsNfaStatesBuilder.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsNfaStatesBuilder.kt
@@ -18,7 +18,75 @@ package com.amazon.ionschema.internal.constraint
 import com.amazon.ion.IonValue
 
 /**
- * Builds a NFA for the `ordered_elements` constraint
+ * Builds states and edges for a [NFA] for the `ordered_elements` constraint.
+ *
+ * In this case, the `NFA`'s `Event` type parameter is an [IonValue] from the input that is being validated by the
+ * Ion Schema System, and [NFA.State] is used to model an entry in the `ordered_elements` list.
+ *
+ * ### Example
+ * Given this ISL fragment:
+ * ```ion
+ * ordered_elements: [
+ *   symbol,
+ *   { type: number, occurs: optional },
+ *   { type: int, occurs: range::[2, 4] },
+ * ]
+ * ```
+ * The [OrderedElementsNfaStatesBuilder] would create the following states:
+ * ```markdown
+ * | ID |     Entry Condition     | Re-entry Condition | Exit Condition |
+ * |----|:-----------------------:|:------------------:|:--------------:|
+ * | 1  | ionValue.type == symbol |     visits <= 1    |   visits >= 1  |
+ * | 2  | ionValue.type == number |     visits <= 1    |   visits >= 0  |
+ * | 3  | ionValue.type == int    |     visits <= 4    |   visits >= 2  |
+ * ```
+ * And then combine them to form this graph:
+ * ```
+ *                               +--+
+ *                               |  |
+ *                               |  v
+ * +------+      +------+      +------+     +-------+
+ * | INIT |----> |  S1  |----> |  S3  |---->| FINAL |
+ * +------+      +------+      +------+     +-------+
+ *                  |              ^
+ *                  v              |
+ *               +------+          |
+ *               |  S2  |----------+
+ *               +------+
+ * ```
+ * Once these have been used to construct the [NFA] instance, the [OrderedElements] constraint implementation can call
+ * [NFA.matches] to determine if a sequence of Ion values is accepted by the NFA.
+ *
+ * When there are no ambiguous choices, it is simple.
+ * Input: `(foo 1.0 2 3)`
+ * ```
+ *      : [I:1]
+ *    0 : [S1:1]
+ *    1 : [S2:1]
+ *    2 : [S3:1]
+ *    3 : [S3:2]
+ *  END : [F:1]
+ * ```
+ *
+ * In this case we have an ambiguous choice—the `1` could be the optional `number` or it could be one of the 2 or more `int`s.
+ * Input: `(foo 1 2 3)`
+ * ```
+ *      : [I:1]
+ *    0 : [S1:1]
+ *    1 : [S2:1, S3:1]  <-- Ambiguous choice, so track both possible paths
+ *    2 : [S3:1, S3:2]
+ *    3 : [S3:2, S3:3]  <-- Note that the paths are at the same state, but
+ *  END : [F:1]             each has a different number of visits.
+ * ```
+ * When there are no valid transitions, it  transitions to "nowhere" (ie. the path through the graph "dies off").
+ * Input: `(foo 1 "Hi!")`
+ * ```
+ *      : [I:1]
+ *    0 : [S1:1]
+ *    1 : [S2:1, S3:1]  <-- Neither one of these paths have a valid transition for `"Hi!"`,
+ *    2 : []                so they both die off. There are 0 possible paths remaining.
+ *  END : []
+ * ```
  */
 internal class OrderedElementsNfaStatesBuilder {
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IntRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IntRange.kt
@@ -109,8 +109,8 @@ private class IntRangeForIonSymbol private constructor(
     override fun toString() = ion.toString()
 }
 
-internal interface IntRangeBoundary {
-    operator fun compareTo(other: Int) = compareTo(BigInteger.valueOf(other.toLong()))
+internal interface IntRangeBoundary : Comparable<Int> {
+    override operator fun compareTo(other: Int) = compareTo(BigInteger.valueOf(other.toLong()))
     operator fun compareTo(other: BigInteger): Int
 }
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/NFATest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/NFATest.kt
@@ -1,0 +1,194 @@
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ionschema.internal.constraint.NFA.State.Final
+import com.amazon.ionschema.internal.constraint.NFA.State.Initial
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Collections
+
+class NFATest {
+
+    /** Helper function to construct a State */
+    private fun state(id: Int, min: Int = 1, max: Int = min) = NFA.State.Intermediate(id, id::equals, reentryCondition = { it <= max }, exitCondition = { it >= min })
+
+    @Test
+    fun `trivial case should be handled correctly`() {
+        val nfa = NFA(mapOf(Initial to setOf(Final)))
+
+        assertTrue(nfa.matches(listOf()))
+
+        assertFalse(nfa.matches(listOf(1)))
+        assertFalse(nfa.matches(listOf(1, 2)))
+        assertFalse(nfa.matches(listOf(1, 2, 3)))
+    }
+
+    @Test
+    fun `simple cases should be handled correctly`() {
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(state(1)),
+                state(1) to setOf(state(2)),
+                state(2) to setOf(state(3)),
+                state(3) to setOf(Final),
+            )
+        )
+
+        assertTrue(nfa.matches(listOf(1, 2, 3)))
+
+        assertFalse(nfa.matches(listOf()))
+        assertFalse(nfa.matches(listOf(1)))
+        assertFalse(nfa.matches(listOf(1, 2)))
+        assertFalse(nfa.matches(listOf(1, 2, 3, 3)))
+        assertFalse(nfa.matches(listOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun `branching graph cases should be handled correctly`() {
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(state(1)),
+                state(1) to setOf(state(2), state(3)),
+                state(2) to setOf(Final),
+                state(3) to setOf(Final),
+            )
+        )
+
+        assertTrue(nfa.matches(listOf(1, 2)))
+        assertTrue(nfa.matches(listOf(1, 3)))
+
+        assertFalse(nfa.matches(listOf()))
+        assertFalse(nfa.matches(listOf(1)))
+        assertFalse(nfa.matches(listOf(1, 2, 3)))
+        assertFalse(nfa.matches(listOf(1, 3, 2)))
+    }
+
+    @Test
+    fun `cycles should be handled correctly`() {
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(state(1)),
+                state(1) to setOf(state(2)),
+                state(2) to setOf(state(3)),
+                state(3) to setOf(state(1), Final),
+            )
+        )
+        assertTrue(nfa.matches(listOf(1, 2, 3)))
+        assertTrue(nfa.matches(listOf(1, 2, 3, 1, 2, 3)))
+        assertTrue(nfa.matches(listOf(1, 2, 3, 1, 2, 3, 1, 2, 3)))
+    }
+
+    @Test
+    fun `loops should be handled correctly`() {
+        val s1 = state(1, max = Int.MAX_VALUE)
+
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(s1),
+                s1 to setOf(s1, Final),
+            )
+        )
+
+        assertTrue(nfa.matches(listOf(1)))
+        assertTrue(nfa.matches(listOf(1, 1)))
+        assertTrue(nfa.matches(listOf(1, 1, 1)))
+        assertTrue(nfa.matches(Collections.nCopies(12345, 1)))
+    }
+
+    @Test
+    fun `max number of loops should be enforceable with the re-entry condition`() {
+        val s1 = state(1, max = 3)
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(s1),
+                s1 to setOf(s1, Final),
+            )
+        )
+
+        assertTrue(nfa.matches(listOf(1)))
+        assertTrue(nfa.matches(listOf(1, 1)))
+        assertTrue(nfa.matches(listOf(1, 1, 1)))
+        assertFalse(nfa.matches(listOf(1, 1, 1, 1)))
+    }
+
+    @Test
+    fun `looping should be required when there is an appropriate exit condition`() {
+        val s1 = state(1, min = 3, max = Int.MAX_VALUE)
+        val nfa = NFA(
+            mapOf(
+                Initial to setOf(s1),
+                s1 to setOf(s1, Final),
+            )
+        )
+
+        assertFalse(nfa.matches(listOf(1)))
+        assertFalse(nfa.matches(listOf(1, 1)))
+        assertTrue(nfa.matches(listOf(1, 1, 1)))
+        assertTrue(nfa.matches(listOf(1, 1, 1, 1)))
+    }
+
+    @Test
+    fun `state transition graph must have Initial state`() {
+        assertThrows<IllegalArgumentException> {
+            NFA(
+                mapOf(
+                    state(1) to setOf(state(2)),
+                    state(2) to setOf(state(1), Final),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `state transition graph must have at least one transition from Initial state`() {
+        assertThrows<IllegalArgumentException> {
+            NFA(
+                mapOf(
+                    Initial to emptySet<NFA.State<Int>>(),
+                    state(1) to setOf(state(2)),
+                    state(2) to setOf(state(1), Final),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `state transition graph must not have any transition to an unknown state`() {
+        assertThrows<IllegalArgumentException> {
+            NFA(
+                mapOf(
+                    Initial to setOf(state(1)),
+                    state(1) to setOf(state(2)),
+                    state(2) to setOf(state(3), Final),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `state transition graph must have a transition to Final state`() {
+        assertThrows<IllegalArgumentException> {
+            NFA(
+                mapOf(
+                    Initial to setOf(state(1)),
+                    state(1) to setOf(state(2)),
+                    state(2) to setOf(state(1)),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `state transition graph must not have a transition from Final state`() {
+        assertThrows<IllegalArgumentException> {
+            NFA(
+                mapOf(
+                    Initial to setOf(state(1)),
+                    state(1) to setOf(Final),
+                    Final to setOf(state(1))
+                )
+            )
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import com.amazon.ionschema.Violations
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+
+class OrderedElementsTest {
+    val ISS = IonSchemaSystemBuilder.standard().build()
+    val ION = ISS.ionSystem
+
+    @ParameterizedTest(name = "ordered_elements:{0} should {1} {2}")
+    @MethodSource("testCases")
+    fun test(ionText: String, ignored: String, value: String, expectValid: Boolean) {
+        val constraint = OrderedElements(ION.singleValue(ionText), ISS.newSchema())
+        val v = Violations()
+        constraint.validate(ION.singleValue(value), v)
+        assertEquals(expectValid, v.isValid())
+    }
+
+    companion object {
+        private val testCases = mapOf(
+            "[{occurs:optional, type:int},{occurs:optional, type:number}]" to values(
+                valid = listOf("[]", "[1]", "[1.0]", "[1, 2]", "[1, 2.0]"),
+                invalid = listOf("[1.0, 2]", "[1, 2, 3]")
+            ),
+            "[{occurs:optional, type:int}, number]" to values(
+                valid = listOf("[1]", "[1.0]", "[1, 2]", "[1, 2.0]"),
+                invalid = listOf("[]", "[1.0, 2]", "[1, 2, 3]")
+            ),
+
+            "[int, {occurs:optional, type:number}]" to values(
+                valid = listOf("[1]", "[1, 2]", "[1, 2.0]"),
+                invalid = listOf("[]", "[1.0]", "[1.0, 2]", "[1, 2, 3]")
+            ),
+        )
+
+        private fun values(valid: List<String>, invalid: List<String>) = Pair(valid, invalid)
+
+        @JvmStatic
+        fun testCases(): Iterable<Arguments> = testCases.entries.flatMap { (orderedElements, values) ->
+            val valid = values.first.map { Arguments { arrayOf(orderedElements, "accept", it, true) } }
+            val invalid = values.second.map { Arguments { arrayOf(orderedElements, "reject", it, false) } }
+            valid + invalid
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
@@ -17,10 +17,10 @@ package com.amazon.ionschema.internal.constraint
 
 import com.amazon.ionschema.IonSchemaSystemBuilder
 import com.amazon.ionschema.Violations
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import kotlin.test.assertEquals
 
 class OrderedElementsTest {
     val ISS = IonSchemaSystemBuilder.standard().build()
@@ -31,7 +31,7 @@ class OrderedElementsTest {
     fun test(ionText: String, ignored: String, value: String, expectValid: Boolean) {
         val constraint = OrderedElements(ION.singleValue(ionText), ISS.newSchema())
         val v = Violations()
-        constraint.validate(ION.singleValue(value), v)
+        constraint.validate(ION.singleValue(value), v, debug = true)
         assertEquals(expectValid, v.isValid())
     }
 


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/amzn/ion-schema/issues/62

**Description of changes:**

Fixes the incorrect behavior described in https://github.com/amzn/ion-schema/issues/62. Also updates the `ion-schema-tests` submodule to the latest commit.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema-tests/pull/18

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
