### PR TITLE
Fix timestamp precision ranges to allow 'min' and 'max'

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
@@ -46,11 +46,10 @@ internal class RangeIonTimestampPrecision(
         ion.forEachIndexed { index, ionValue ->
             val isValid = try {
                 if (ionValue is IonSymbol && !ionValue.isNullValue) {
-                    val itp = IonTimestampPrecision.valueOf(ionValue.stringValue())
                     val ionInt = when (ionValue.stringValue()) {
-                        "min" -> ion.system.newInt(Int.MIN_VALUE)
-                        "max" -> ion.system.newInt(Int.MAX_VALUE)
-                        else -> ion.system.newInt(itp.id)
+                        "min" -> ionValue.clone()
+                        "max" -> ionValue.clone()
+                        else -> ion.system.newInt(IonTimestampPrecision.valueOf(ionValue.stringValue()).id)
                     }
                     ionValue.typeAnnotations.forEach { ionInt.addTypeAnnotation(it) }
                     intRangeIon.add(ionInt)


### PR DESCRIPTION
**Issue #, if available:**

Fixes #193 

**Description of changes:**

Changes `RangeIonTimestampPrecision` so that calling `valueOf()` for the `IonTimestampPrecision` happens after the check for `min` and `max`. Also now it passes the symbols `min` and `max` to the range delegate instead of converting them to `Int.MIN_VALUE` and `Int.MAX_VALUE`.

Updates the `ion-schema-tests` submodule to have the test cases from https://github.com/amzn/ion-schema-tests/pull/19.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema-tests/pull/19

**_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._**
