### PR TITLE
Fixes codepoint_length incorrectly counting multi-unit codepoints

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/CodepointLength.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/CodepointLength.kt
@@ -30,5 +30,5 @@ internal class CodepointLength(
     override val violationCode = "invalid_codepoint_length"
     override val violationMessage = "invalid codepoint length %s, expected %s"
 
-    override fun getIntValue(value: IonText) = value.stringValue().length
+    override fun getIntValue(value: IonText) = value.stringValue().let { it.codePointCount(0, it.length) }
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #190 

**Description of changes:**

Changes validation to use `String.codePointCount` instead of `String.length`.

Updates the `ion-schema-tests` submodule to have the test cases from https://github.com/amzn/ion-schema-tests/pull/20.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema-tests/pull/20


**_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._**
