### PR TITLE
Adds code coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,29 @@
-name: CI Build
+name: "Build and Report Generation"
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run this job on pull_request events for
+      # branches that look like fork branches. Without this we would end up running this job twice for non-forked
+      # PRs, once for the push and then once for opening the PR.
+      # Taken from https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
+      - '**:**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 9, 10, 11]
+        java: [8, 11]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: corretto
           java-version: ${{ matrix.java }}
       - name: Cache Gradle packages
         uses: actions/cache@v1
@@ -28,3 +33,23 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Build with Gradle
         run: ./gradlew build
+  report-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Use Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+      - run: ./gradlew jacocoTestReport
+      - name: Upload Ion Schema Code Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ion-schema/build/reports/jacoco/test/jacocoTestReport.xml
+      - name: Upload CLI Code Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: cli/build/reports/jacoco/test/jacocoTestReport.xml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ written in Kotlin.
 [![Build Status](https://travis-ci.org/amzn/ion-schema-kotlin.svg)](https://travis-ci.org/amzn/ion-schema-kotlin)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-schema-kotlin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-schema-kotlin)
 [![Javadoc](https://javadoc-badge.appspot.com/com.amazon.ion/ion-schema-kotlin.svg?label=javadoc)](http://www.javadoc.io/doc/com.amazon.ion/ion-schema-kotlin)
+[![codecov](https://codecov.io/gh/amzn/ion-schema-kotlin/branch/master/graph/badge.svg)](https://codecov.io/gh/amzn/ion-schema-kotlin)
 
 ## Getting Started
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,19 +26,44 @@ buildscript {
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.6.20" apply false
     id "org.jlleitschuh.gradle.ktlint" version "10.0.0" apply false
+    id 'jacoco'
 }
 
-subprojects {
-    group = 'com.amazon.ion'
-    ext.kotlin_version = "1.6.20"
+allprojects {
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"
     ktlint {
         outputToConsole = true
     }
 
+    apply plugin: "jacoco"
+    jacoco {
+        toolVersion = '0.8.7'
+        reportsDirectory = file("$buildDir/reports/jacoco/")
+    }
+}
+
+subprojects {
+    group = 'com.amazon.ion'
+    ext.kotlin_version = "1.6.20"
+
+    apply plugin: "org.jetbrains.kotlin.jvm"
     tasks.withType(Test) {
         useJUnitPlatform()
+        jacocoTestReport {
+            reports {
+                xml.required.set(true) // Required for codecov upload
+                html.required.set(true) // Required for humans
+                html.outputLocation.set(file("${buildDir}/reports/jacoco/html"))
+            }
+        }
+    }
+
+    tasks.jacocoTestReport {
+        dependsOn(tasks.test) // tests are required to run before generating the report
+        doLast {
+            logger.quiet "Coverage report written to file://${reports.html.destination.toPath()}/index.html"
+        }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

When working on a recent bugfix, I realized that we didn't have any code coverage analysis as part of the gradle build. So, this change adds the `jacoco` gradle plugin. It also updates the `main.yml` github workflow to generate the coverage reports and upload them to codecov. (I took the liberty of setting up the codecov app for `ion-schema-kotlin` already.)

...and while I was working on that github workflow, I took the opportunity to do a little housecleaning. I removed the non-LTS versions of java from the build matrix, switched to the Corretto JDK distribution, updated some of the github actions to the latest version of the action, and changed the triggers of the workflow so that it will try to build changes regardless of the branch.



**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

N/A

**_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._**
