### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/ion-schema/build.gradle
+++ b/ion-schema/build.gradle
@@ -20,7 +20,7 @@ plugins {
   id "signing"
 }
 
-version = "1.2.1-SNAPSHOT"
+version = "1.3.0"
 
 repositories {
   mavenCentral()
@@ -103,7 +103,7 @@ publishing {
             name = "Amazon Ion Team"
             email = "ion-team@amazon.com"
             organization = "Amazon"
-            organizationUrl = "https://github.com/amzn"
+            organizationUrl = "https://github.com/amazon-ion"
           }
         }
       }


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

There have been a few bugfixes. This bumps to a new minor version in preparation of a new release. It also updates the developer organization URL in the publish plugin to point to the `amazon-ion` GitHub organiation.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
N/A

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
