### PR TITLE
Adds early-exit logic to `any_of` implementation

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/LogicConstraints.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/LogicConstraints.kt
@@ -77,10 +77,13 @@ internal class AllOf(ion: IonValue, schema: Schema) : LogicConstraints(ion, sche
 internal class AnyOf(ion: IonValue, schema: Schema) : LogicConstraints(ion, schema) {
     override fun validate(value: IonValue, issues: Violations) {
         val anyOfViolation = Violation(ion, "no_types_matched", "value matches none of the types")
-        val count = validateTypes(value, anyOfViolation).size
-        if (count == 0) {
-            issues.add(anyOfViolation)
+        types.forEach {
+            val checkpoint = anyOfViolation.checkpoint()
+            it().validate(value, anyOfViolation)
+            // We can exit at the first valid type we encounter
+            if (checkpoint.isValid()) return
         }
+        issues.add(anyOfViolation)
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**

Fixes #200

**Description of changes:**

Returns without adding a violation/issue as soon as the first match is discovered.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

N/A

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
