### PR TITLE
Fixes incorrect fast-fail evaluation of timestamps with unknown offset

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IntRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IntRange.kt
@@ -42,8 +42,8 @@ internal interface IntRange {
     val lower: IntRangeBoundary
     val upper: IntRangeBoundary
 
-    fun contains(value: Int) = contains(BigInteger.valueOf(value.toLong()))
-    fun contains(value: BigInteger): Boolean
+    operator fun contains(value: Int) = contains(BigInteger.valueOf(value.toLong()))
+    operator fun contains(value: BigInteger): Boolean
 }
 
 private class IntRangeForIonList(
@@ -71,7 +71,7 @@ private class IntRangeForIonList(
         else -> throw InvalidSchemaException("Unable to parse upper bound of $ion")
     }
 
-    override fun contains(value: BigInteger) = lower <= value && upper >= value
+    override operator fun contains(value: BigInteger) = lower <= value && upper >= value
     override fun toString() = ion.toString()
 }
 
@@ -87,7 +87,7 @@ private class IntRangeForIonInt(
 
     override val lower = boundary
     override val upper = boundary
-    override fun contains(value: BigInteger) = theValue == value
+    override operator fun contains(value: BigInteger) = theValue == value
     override fun toString() = ion.toString()
 }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Range.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Range.kt
@@ -36,7 +36,7 @@ internal enum class RangeType {
  * Interface for all range implementations.
  */
 internal interface Range<in T> {
-    fun contains(value: T): Boolean
+    operator fun contains(value: T): Boolean
 }
 
 /**

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeBigDecimal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeBigDecimal.kt
@@ -73,7 +73,7 @@ internal class RangeBigDecimal(private val ion: IonList) : Range<BigDecimal> {
         }
     }
 
-    override fun contains(value: BigDecimal) = lower <= value && upper >= value
+    override operator fun contains(value: BigDecimal) = lower <= value && upper >= value
 
     override fun toString() = ion.toString()
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeInt.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeInt.kt
@@ -50,7 +50,7 @@ internal class RangeInt(
         }
     }
 
-    override fun contains(value: Int) = delegate.contains(value.toBigDecimal())
+    override operator fun contains(value: Int) = delegate.contains(value.toBigDecimal())
 
     internal fun isAtMax(value: Int) = delegate.upper.compareTo(value.toBigDecimal()) == 0
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonNumber.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonNumber.kt
@@ -46,7 +46,7 @@ internal class RangeIonNumber private constructor (
             }
     }
 
-    override fun contains(value: IonValue): Boolean {
+    override operator fun contains(value: IonValue): Boolean {
         val bdValue = toBigDecimal(value)
         return if (bdValue != null) {
             delegate.contains(bdValue)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
@@ -54,7 +54,7 @@ internal class RangeIonTimestamp private constructor (
         }
     }
 
-    override fun contains(value: IonTimestamp): Boolean {
+    override operator fun contains(value: IonTimestamp): Boolean {
         // ValidValues performs this same check and adds a Violation
         // instead of invoking this method;  this if is here purely
         // as a defensive safety check, and will ideally never be true

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestampPrecision.kt
@@ -73,7 +73,7 @@ internal class RangeIonTimestampPrecision(
         delegate = RangeFactory.rangeOf<Int>(intRangeIon, RangeType.INT)
     }
 
-    override fun contains(value: IonTimestamp) = delegate.contains(IonTimestampPrecision.toInt(value))
+    override operator fun contains(value: IonTimestamp) = delegate.contains(IonTimestampPrecision.toInt(value))
 }
 
 /**


### PR DESCRIPTION
**Issue #, if available:**

No issue, but this fixes the bug described in https://github.com/amzn/ion-schema-tests/pull/22

**Description of changes:**

* Updates `ion-schema-kotlin` to have the latest changes in `ion-schema-tests` (see related PRs below)
* Adds the `operator` keyword to the `contains` functions for all `Range` implementations. This is not strictly necessary, but it makes the changes in `valid_values` implementation a little more concise, and I added it to all of the other `Range`s for consistency.
* Fixes `valid_values` implementation so that it doesn't fail fast (regardless of other possible values) when a timestamp with unknown offset is compared with a range.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema-tests/pull/22
https://github.com/amzn/ion-schema-tests/pull/23


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
