### PR TITLE
Updates annotations and valid_values constraints w.r.t. documents

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations.kt
@@ -15,12 +15,14 @@
 
 package com.amazon.ionschema.internal.constraint
 
+import com.amazon.ion.IonDatagram
 import com.amazon.ion.IonList
 import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.CommonViolations
 import com.amazon.ionschema.internal.Constraint
 import com.amazon.ionschema.internal.util.IntRange
 import com.amazon.ionschema.internal.util.withoutTypeAnnotations
@@ -94,6 +96,11 @@ internal class OrderedAnnotations(
     }
 
     override fun validate(value: IonValue, issues: Violations) {
+        if (value is IonDatagram) {
+            issues.add(CommonViolations.INVALID_TYPE(ion, value))
+            return
+        }
+
         if (!stateMachine.matches(value.typeAnnotations.map { ION.newSymbol(it) }.iterator())) {
             issues.add(Violation(ion, "annotations_mismatch", "annotations don't match expectations"))
         }
@@ -111,6 +118,11 @@ internal class UnorderedAnnotations(
     private val closedAnnotationStrings: List<String>? = if (ion.hasTypeAnnotation("closed")) (ion as IonList).map { (it as IonSymbol).stringValue() } else null
 
     override fun validate(value: IonValue, issues: Violations) {
+        if (value is IonDatagram) {
+            issues.add(CommonViolations.INVALID_TYPE(ion, value))
+            return
+        }
+
         val missingAnnotations = mutableListOf<Annotation>()
         annotations.forEach {
             if (it.isRequired && !value.hasTypeAnnotation(it.text)) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/ValidValues.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/ValidValues.kt
@@ -80,6 +80,10 @@ internal class ValidValues(
         }
 
     override fun validate(value: IonValue, issues: Violations) {
+        // FYI--a document/IonDatagram is never valid for the valid_values constraint.
+        // However, we don't need to test for it because there's no way to construct
+        // a valid_values that could match an IonDatagram.
+
         val v = value.withoutTypeAnnotations()
         val matchesAny = validValues!!.any { possibility ->
             when (possibility) {


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

* Updates `annotations` implementation to reject `document`s
* Adds a note to `valid_values`
* Updates to the latest commit in the `ion-schema-tests` submodule


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema/pull/73
https://github.com/amzn/ion-schema-tests/pull/24

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
