### PR TITLE
Fixes timestamp ranges incorrectly rejecting timestamps with unknown offsets

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/ValidValues.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/ValidValues.kt
@@ -91,7 +91,6 @@ internal class ValidValues(
                 is RangeIonNumber -> v in possibility
                 is RangeIonTimestamp -> when {
                     v !is IonTimestamp -> false
-                    v.localOffset == null -> false
                     else -> v in possibility
                 }
                 else -> TODO("This is unreachable.")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
@@ -55,12 +55,6 @@ internal class RangeIonTimestamp private constructor (
     }
 
     override operator fun contains(value: IonTimestamp): Boolean {
-        // ValidValues performs this same check and adds a Violation
-        // instead of invoking this method;  this if is here purely
-        // as a defensive safety check, and will ideally never be true
-        if (value.localOffset == null) {
-            throw IllegalArgumentException("Unable to compare timestamp with unknown local offset: $value")
-        }
         return delegate.contains(value.decimalMillis)
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #204

**Description of changes:**

Fixes `RangeIonTimestamp` and `ValidValues` to not automatically reject timestamps with unknown offsets.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amzn/ion-schema-tests/pull/25

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
