### PR TITLE
Adds SchemaImpl_2_0 with support for a subset of constraints

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -18,9 +18,10 @@ package com.amazon.ionschema.internal
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.IonSchemaVersion.v1_0
+import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.internal.constraint.AllOf
-import com.amazon.ionschema.internal.constraint.Annotations
+import com.amazon.ionschema.internal.constraint.Annotations_1_0
 import com.amazon.ionschema.internal.constraint.AnyOf
 import com.amazon.ionschema.internal.constraint.ByteLength
 import com.amazon.ionschema.internal.constraint.CodepointLength
@@ -61,28 +62,28 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
     }
 
     private val constraints = listOf(
-        ConstraintConstructor("all_of", v1_0, ::AllOf),
-        ConstraintConstructor("annotations", v1_0, ::Annotations),
-        ConstraintConstructor("any_of", v1_0, ::AnyOf),
-        ConstraintConstructor("byte_length", v1_0, ::ByteLength),
-        ConstraintConstructor("codepoint_length", v1_0, ::CodepointLength),
-        ConstraintConstructor("container_length", v1_0, ::ContainerLength),
-        ConstraintConstructor("contains", v1_0, ::Contains),
+        ConstraintConstructor("all_of", v1_0..v2_0, ::AllOf),
+        ConstraintConstructor("annotations", v1_0, ::Annotations_1_0),
+        ConstraintConstructor("any_of", v1_0..v2_0, ::AnyOf),
+        ConstraintConstructor("byte_length", v1_0..v2_0, ::ByteLength),
+        ConstraintConstructor("codepoint_length", v1_0..v2_0, ::CodepointLength),
+        ConstraintConstructor("container_length", v1_0..v2_0, ::ContainerLength),
+        ConstraintConstructor("contains", v1_0..v2_0, ::Contains),
         ConstraintConstructor("content", v1_0, ::Content),
         ConstraintConstructor("element", v1_0, ::Element),
         ConstraintConstructor("fields", v1_0, ::Fields),
-        ConstraintConstructor("not", v1_0, ::Not),
+        ConstraintConstructor("not", v1_0..v2_0, ::Not),
         ConstraintConstructor("occurs", v1_0, ::OccursNoop),
-        ConstraintConstructor("one_of", v1_0, ::OneOf),
+        ConstraintConstructor("one_of", v1_0..v2_0, ::OneOf),
         ConstraintConstructor("ordered_elements", v1_0, ::OrderedElements),
-        ConstraintConstructor("precision", v1_0, ::Precision),
+        ConstraintConstructor("precision", v1_0..v2_0, ::Precision),
         ConstraintConstructor("regex", v1_0, ::Regex),
         ConstraintConstructor("scale", v1_0, ::Scale),
-        ConstraintConstructor("timestamp_offset", v1_0, ::TimestampOffset),
-        ConstraintConstructor("timestamp_precision", v1_0, ::TimestampPrecision),
-        ConstraintConstructor("type", v1_0, ::Type),
-        ConstraintConstructor("utf8_byte_length", v1_0, ::Utf8ByteLength),
-        ConstraintConstructor("valid_values", v1_0, ::ValidValues),
+        ConstraintConstructor("timestamp_offset", v1_0..v2_0, ::TimestampOffset),
+        ConstraintConstructor("timestamp_precision", v1_0..v2_0, ::TimestampPrecision),
+        ConstraintConstructor("type", v1_0..v2_0, ::Type),
+        ConstraintConstructor("utf8_byte_length", v1_0..v2_0, ::Utf8ByteLength),
+        ConstraintConstructor("valid_values", v1_0..v2_0, ::ValidValues),
     )
 
     override fun isConstraint(name: String, version: IonSchemaVersion): Boolean {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -38,6 +38,7 @@ internal class IonSchemaSystemImpl(
 
     private val schemaCores = mapOf(
         IonSchemaVersion.v1_0 to SchemaCore(this, IonSchemaVersion.v1_0),
+        IonSchemaVersion.v2_0 to SchemaCore(this, IonSchemaVersion.v2_0)
     )
 
     // Set to be used to detect cycle in import dependencies

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl.kt
@@ -22,7 +22,7 @@ internal interface SchemaImpl : Schema {
             val content = schemaContent.asSequence().toList()
             return when (val version = findIslVersion(content)) {
                 IonSchemaVersion.v1_0 -> SchemaImpl_1_0(schemaSystem, schemaCores[version]!!, content.iterator(), schemaId)
-                else -> TODO("Ion Schema 2.0 support is not complete yet")
+                IonSchemaVersion.v2_0 -> SchemaImpl_2_0(schemaSystem, schemaCores[version]!!, content.iterator(), schemaId)
             }
         }
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonDatagram
+import com.amazon.ion.IonList
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonText
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.Import
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.Schema
+import com.amazon.ionschema.Type
+import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.util.ISL_2_0_RESERVED_WORDS_REGEX
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.markReadOnly
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Implementation of [Schema] for all user-provided ISL.
+ *
+ * TODO: Handle user content in header, footer.
+ */
+internal class SchemaImpl_2_0 private constructor(
+    private val schemaSystem: IonSchemaSystemImpl,
+    private val schemaCore: SchemaCore,
+    schemaContent: Iterator<IonValue>,
+    override val schemaId: String?,
+    preloadedImports: Map<String, Import>,
+        /*
+         * [types] is declared as a MutableMap in order to be populated DURING
+         * INITIALIZATION ONLY.  This enables type B to find its already-loaded
+         * dependency type A.  After initialization, [types] is expected to
+         * be treated as immutable as required by the Schema interface.
+         */
+    private val types: MutableMap<String, Type>
+) : SchemaImpl {
+
+    internal constructor(
+        schemaSystem: IonSchemaSystemImpl,
+        schemaCore: SchemaCore,
+        schemaContent: Iterator<IonValue>,
+        schemaId: String?
+    ) : this(schemaSystem, schemaCore, schemaContent, schemaId, emptyMap(), mutableMapOf())
+
+    private val deferredTypeReferences = mutableListOf<TypeReferenceDeferred>()
+
+    override val isl: IonDatagram
+
+    private val imports: Map<String, Import>
+
+    private val declaredTypes: Map<String, TypeImpl>
+
+    override val ionSchemaLanguageVersion: IonSchemaVersion
+        get() = IonSchemaVersion.v2_0
+
+    companion object {
+        private val ISL_VERSION_MARKER = Regex("^\\\$ion_schema_\\d.*")
+    }
+
+    init {
+        val dgIsl = schemaSystem.ionSystem.newDatagram()
+
+        if (types.isEmpty()) {
+
+            var foundVersionMarker = false
+            var foundHeader = false
+            var foundFooter = false
+            var foundAnyType = false
+            var importsMap = emptyMap<String, Import>()
+
+            while (schemaContent.hasNext()) {
+                val it = schemaContent.next()
+
+                dgIsl.add(it.clone())
+
+                when {
+                    isVersionMarker(it) -> {
+                        islRequire(it.stringValue() == IonSchemaVersion.v2_0.symbolText) { "Unsupported Ion Schema version: $it" }
+                        islRequire(!foundVersionMarker) { "Only one Ion Schema version marker is allowed in a schema document." }
+                        islRequire(!foundHeader && !foundAnyType && !foundFooter) { "Ion Schema version marker must come before any header, types, and footer." }
+                        foundVersionMarker = true
+                    }
+                    isHeader(it) -> {
+                        if (!foundVersionMarker) throw IllegalStateException("SchemaImpl_2_0 should only be instantiated for an ISL 2.0 schema.")
+                        islRequire(!foundAnyType) { "Schema header must appear before any types." }
+                        islRequire(!foundHeader) { "Only one schema header is allowed in a schema document." }
+                        importsMap = loadHeaderImports(types, it)
+                        foundHeader = true
+                    }
+                    isFooter(it) -> {
+                        islRequire(foundHeader) { "Found a schema_footer, but no schema header precedes it." }
+                        islRequire(!foundFooter) { "Only one schema footer is allowed in a schema document." }
+                        foundFooter = true
+                    }
+                    isType(it) -> {
+                        islRequire(!foundFooter) { "Types may not occur after the schema footer." }
+                        islRequire(it.count { it.fieldName == "name" } == 1) { "Top-level types must have exactly one name." }
+                        val name = islRequireIonTypeNotNull<IonSymbol>(it["name"]) { "Type names must be a non-null symbol." }
+                        islRequire(name.typeAnnotations.isEmpty()) { "Type names must not have annotations." }
+                        val newType = TypeImpl(it, this)
+                        addType(types, newType)
+                        foundAnyType = true
+                    }
+                    isTopLevelOpenContent(it) -> {} // Fine; do nothing.
+                    else -> {
+                        throw InvalidSchemaException("Illegal top-level value in schema document: $it")
+                    }
+                }
+            }
+            islRequire(foundFooter || !foundHeader) { "Found a schema_header, but not a schema_footer" }
+
+            resolveDeferredTypeReferences()
+            imports = importsMap
+        } else {
+            // in this case the new Schema is based on an existing Schema and the 'types'
+            // map was populated by the caller
+            schemaContent.forEach {
+                dgIsl.add(it.clone())
+            }
+            imports = preloadedImports
+        }
+
+        isl = dgIsl.markReadOnly()
+        declaredTypes = types.values.filterIsInstance<TypeImpl>().associateBy { it.name }
+
+        if (declaredTypes.isEmpty()) {
+            schemaSystem.emitWarning { "${WarningType.SCHEMA_HAS_NO_TYPES} -- '$schemaId'" }
+        }
+    }
+
+    private class SchemaAndTypeImports(val id: String, val schema: Schema) {
+        var types: MutableMap<String, Type> = mutableMapOf()
+
+        fun addType(name: String, type: Type) {
+            types[name]?.let {
+                if (it.schemaId != type.schemaId || it.isl != type.isl) {
+                    throw InvalidSchemaException("Duplicate imported type name/alias encountered: '$name'")
+                } else if (it is ImportedType && it.schemaId == it.importedFromSchemaId) {
+                    return@addType
+                }
+            }
+            types[name] = type
+        }
+    }
+
+    /**
+     * See https://amzn.github.io/ion-schema/docs/isl-2-0/spec#open-content
+     */
+    private fun isTopLevelOpenContent(value: IonValue): Boolean {
+        if (value is IonSymbol && ISL_VERSION_MARKER.matches(value.stringValue())) {
+            return false
+        }
+        if (value.typeAnnotations.any { ISL_2_0_RESERVED_WORDS_REGEX.matches(it) }) {
+            return false
+        }
+        return true
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private fun isHeader(value: IonValue): Boolean {
+        contract { returns(true) implies (value is IonStruct) }
+        return value is IonStruct && !value.isNullValue && arrayOf("schema_header").contentDeepEquals(value.typeAnnotations)
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private fun isFooter(value: IonValue): Boolean {
+        contract { returns(true) implies (value is IonStruct) }
+        return value is IonStruct && !value.isNullValue && arrayOf("schema_footer").contentDeepEquals(value.typeAnnotations)
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private fun isVersionMarker(value: IonValue): Boolean {
+        contract { returns(true) implies (value is IonSymbol) }
+        return value is IonSymbol && !value.isNullValue && ISL_VERSION_MARKER.matches(value.stringValue())
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private fun isType(value: IonValue): Boolean {
+        contract { returns(true) implies (value is IonStruct) }
+        return value is IonStruct && !value.isNullValue && arrayOf("type").contentDeepEquals(value.typeAnnotations)
+    }
+
+    private fun loadHeaderImports(
+        typeMap: MutableMap<String, Type>,
+        header: IonStruct
+    ): Map<String, Import> {
+
+        val importsMap = mutableMapOf<String, SchemaAndTypeImports>()
+        val importSet: MutableSet<String> = schemaSystem.getSchemaImportSet()
+
+        (header.get("imports") as? IonList)
+            ?.filterIsInstance<IonStruct>()
+            ?.forEach {
+                val childImportId = it["id"] as IonText
+                val alias = it["as"] as? IonSymbol
+                // if importSet has an import with this id then do not load schema again to break the cycle.
+                if (!importSet.contains(childImportId.stringValue())) {
+                    var parentImportId = schemaId ?: ""
+
+                    // if Schema is importing itself then throw error
+                    if (parentImportId.equals(childImportId.stringValue())) {
+                        throw InvalidSchemaException("Schema can not import itself.")
+                    }
+
+                    // add parent and current schema to importSet and continue loading current schema
+                    importSet.add(parentImportId)
+                    importSet.add(childImportId.stringValue())
+                    val importedSchema = schemaSystem.loadSchema(childImportId.stringValue())
+                    importSet.remove(childImportId.stringValue())
+                    importSet.remove(parentImportId)
+
+                    val schemaAndTypes = importsMap.getOrPut(childImportId.stringValue()) {
+                        SchemaAndTypeImports(childImportId.stringValue(), importedSchema)
+                    }
+
+                    val typeName = (it["type"] as? IonSymbol)?.stringValue()
+                    if (typeName != null) {
+                        var importedType = importedSchema.getDeclaredType(typeName)
+                            ?.toImportedType(childImportId.stringValue())
+
+                        importedType ?: throw InvalidSchemaException("Schema $childImportId doesn't contain a type named '$typeName'")
+
+                        if (alias != null) {
+                            importedType = TypeAliased(alias, importedType)
+                        }
+                        addType(typeMap, importedType)
+                        schemaAndTypes.addType(alias?.stringValue() ?: typeName, importedType)
+                    } else {
+                        val typesToAdd = importedSchema.getDeclaredTypes()
+
+                        typesToAdd.asSequence()
+                            .map { type -> type.toImportedType(childImportId.stringValue()) }
+                            .forEach { type ->
+                                addType(typeMap, type)
+                                schemaAndTypes.addType(type.name, type)
+                            }
+                    }
+                }
+            }
+        return importsMap.mapValues {
+            ImportImpl(it.value.id, it.value.schema, it.value.types)
+        }
+    }
+
+    override fun getImport(id: String) = imports[id]
+
+    override fun getImports() = imports.values.iterator()
+
+    private fun validateType(type: Type) {
+        val struct = type.isl as IonStruct
+        val name = struct["name"]
+        if (name == null || name.isNullValue) {
+            throw InvalidSchemaException(
+                "Top-level types of a schema must have a name ($type.isl)"
+            )
+        }
+    }
+
+    private fun addType(typeMap: MutableMap<String, Type>, type: Type) {
+        validateType(type)
+        getType(type.name)?.let {
+            if (it.schemaId != type.schemaId || it.isl != type.isl) {
+                throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
+            }
+        }
+        typeMap[type.name] = type
+    }
+
+    override fun getType(name: String) = schemaCore.getType(name) ?: types[name]
+
+    override fun getDeclaredType(name: String) = declaredTypes[name]
+
+    override fun getDeclaredTypes(): Iterator<Type> = declaredTypes.values.iterator()
+
+    override fun getTypes(): Iterator<Type> =
+        (schemaCore.getTypes().asSequence() + types.values.asSequence())
+            .filter { it is ImportedType || it is TypeImpl }
+            .iterator()
+
+    override fun newType(isl: String) = newType(
+        schemaSystem.ionSystem.singleValue(isl) as IonStruct
+    )
+
+    override fun newType(isl: IonStruct): Type {
+        val type = TypeImpl(isl, this)
+        resolveDeferredTypeReferences()
+        return type
+    }
+
+    override fun plusType(type: Type): Schema {
+        validateType(type)
+
+        // prepare ISL corresponding to the new Schema
+        // (might be simpler if IonDatagram.set(int, IonValue) were implemented,
+        // see https://github.com/amzn/ion-java/issues/50)
+        val newIsl = schemaSystem.ionSystem.newDatagram()
+        var newTypeAdded = false
+        isl.forEachIndexed { idx, value ->
+            if (!newTypeAdded) {
+                when {
+                    value is IonStruct
+                        && (value["name"] as? IonSymbol)?.stringValue().equals(type.name) -> {
+                        // new type replaces existing type of the same name
+                        newIsl.add(type.isl.clone())
+                        newTypeAdded = true
+                        return@forEachIndexed
+                    }
+                    (value is IonStruct && value.hasTypeAnnotation("schema_footer"))
+                        || idx == isl.lastIndex -> {
+                        newIsl.add(type.isl.clone())
+                        newTypeAdded = true
+                    }
+                }
+            }
+            newIsl.add(value.clone())
+        }
+
+        // clone the types map:
+        val preLoadedTypes = types.toMutableMap()
+        preLoadedTypes[type.name] = type
+        return SchemaImpl_2_0(schemaSystem, schemaCore, newIsl.iterator(), null, imports, preLoadedTypes)
+    }
+
+    override fun getSchemaSystem() = schemaSystem
+
+    override fun addDeferredType(typeRef: TypeReferenceDeferred) {
+        deferredTypeReferences.add(typeRef)
+    }
+
+    private fun resolveDeferredTypeReferences() {
+        val unresolvedDeferredTypeReferences = deferredTypeReferences
+            .filterNot { it.attemptToResolve() }
+            .map { it.name }.toSet()
+
+        if (unresolvedDeferredTypeReferences.isNotEmpty()) {
+            throw InvalidSchemaException(
+                "Unable to resolve type reference(s): $unresolvedDeferredTypeReferences"
+            )
+        }
+    }
+
+    /**
+     * Returns a new [ImportedType] instance that decorates [Type] so that it will
+     * log a transitive import warning every time it is used for validation.
+     */
+    private fun Type.toImportedType(importedFromSchemaId: String): ImportedType {
+        this@toImportedType as TypeInternal
+        return object : ImportedType, TypeInternal by this {
+            override fun validate(value: IonValue, issues: Violations) {
+                if (importedFromSchemaId != schemaId) {
+                    schemaSystem.emitWarning {
+                        warnInvalidTransitiveImport(this, this@SchemaImpl_2_0.schemaId)
+                    }
+                }
+                this@toImportedType.validate(value, issues)
+            }
+
+            override val schemaId: String
+                get() = this@toImportedType.schemaId!!
+            override val importedFromSchemaId: String
+                get() = importedFromSchemaId
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInternal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInternal.kt
@@ -28,8 +28,10 @@ internal interface TypeInternal : Type, Constraint {
      */
     val schemaId: String?
 
+    @Deprecated("Only used for Ion Schema 1.0 code paths. No new usages should be introduced.")
     fun getBaseType(): TypeBuiltin
 
+    @Deprecated("Only used for Ion Schema 1.0 code paths. No new usages should be introduced.")
     fun isValidForBaseType(value: IonValue): Boolean
 }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeOrNullDecorator.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeOrNullDecorator.kt
@@ -17,32 +17,31 @@ package com.amazon.ionschema.internal
 
 import com.amazon.ion.IonType
 import com.amazon.ion.IonValue
-import com.amazon.ionschema.IonSchemaVersion.v1_0
+import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.constraint.ConstraintBase
 import com.amazon.ionschema.internal.util.islRequire
 
 /**
- * [Type] decorator that implements the nullable:: annotation.
+ * [Type] decorator that implements the $null_or:: annotation.
+ *
+ * Name of this class is `TypeOrNull...` instead of `NullOrType...` to be consistent with other Type-based classes.
  */
-internal class TypeNullable(
+internal class TypeOrNullDecorator(
     ion: IonValue,
     private val type: TypeInternal,
     schema: Schema
 ) : TypeInternal by type, ConstraintBase(ion) {
 
     init {
-        islRequire(schema.ionSchemaLanguageVersion == v1_0) { "'nullable::' is not supported beyond Ion Schema 1.0" }
-        islRequire(type.getBaseType() != schema.getType("document")) { "The 'document' type is not nullable" }
+        islRequire(schema.ionSchemaLanguageVersion >= v2_0) { "'\$null_or::' not supported before Ion Schema 2.0" }
     }
 
     override fun validate(value: IonValue, issues: Violations) {
-        if (!(
-            value.isNullValue &&
-                (value.type == IonType.NULL || type.isValidForBaseType(value))
-            )
-        ) {
+        if (value.type == IonType.NULL) {
+            return
+        } else {
             type.validate(value, issues)
         }
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_1_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_1_0.kt
@@ -34,7 +34,7 @@ import com.amazon.ionschema.internal.util.withoutTypeAnnotations
  *
  * @see https://amzn.github.io/ion-schema/docs/spec.html#annotations
  */
-internal class Annotations private constructor(
+internal class Annotations_1_0 private constructor(
     ion: IonValue,
     private val delegate: Constraint
 ) : ConstraintBase(ion), Constraint by delegate {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Contains.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Contains.kt
@@ -32,7 +32,9 @@ internal class Contains(
 ) : ConstraintBase(ion) {
 
     private val expectedElements = if (ion !is IonList || ion.isNullValue) {
-        throw InvalidSchemaException("Expected annotations as a list, found: $ion")
+        throw InvalidSchemaException("Expected values in a list, found: $ion")
+    } else if (ion.typeAnnotations.isNotEmpty()) {
+        throw InvalidSchemaException("List of values may not be annotated.")
     } else {
         ion.toArray()
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/TimestampOffset.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/TimestampOffset.kt
@@ -54,12 +54,18 @@ internal class TimestampOffset(
         if (ion.size == 0) {
             throw InvalidSchemaException("timestamp_offset must contain at least one offset")
         }
+        if (ion.typeAnnotations.isNotEmpty()) {
+            throw InvalidSchemaException("timestamp_offset list may not be annotated")
+        }
 
         validOffsets = ion.map {
             // every timestamp offset must be of the form "[+|-]hh:mm"
 
-            if (it !is IonString) {
-                throw InvalidSchemaException("timestamp_offset values must be strings, found $it")
+            if (it !is IonString || it.isNullValue) {
+                throw InvalidSchemaException("timestamp_offset values must be non-null strings, found $it")
+            }
+            if (it.typeAnnotations.isNotEmpty()) {
+                throw InvalidSchemaException("timestamp_offset values may not be annotated, found $it")
             }
             val str = it.stringValue()
             if (str == "-00:00") {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0_Util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0_Util.kt
@@ -1,0 +1,6 @@
+package com.amazon.ionschema.internal.util
+
+/**
+ * See https://amzn.github.io/ion-schema/docs/isl-2-0/spec#reserved-symbols
+ */
+internal val ISL_2_0_RESERVED_WORDS_REGEX = Regex("(\\\$ion_schema(_.*)?|[a-z][a-z\\d]*(_[a-z\\d]+)*)")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.util
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun islRequire(value: Boolean, lazyMessage: () -> Any) {
+    contract { returns() implies value }
+    if (!value) throw InvalidSchemaException(lazyMessage().toString())
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <reified T : Any> islRequireNotNull(value: T?, lazyMessage: () -> Any): T {
+    contract { returns() implies (value is T) }
+    if (value !is T) throw InvalidSchemaException(lazyMessage().toString())
+    return value
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <reified T : IonValue> islRequireIonNotNull(value: T?, lazyMessage: () -> Any): T {
+    contract { returns() implies (value is T) }
+    if (value !is T || value.isNullValue) throw InvalidSchemaException(lazyMessage().toString())
+    return value
+}
+
+@OptIn(ExperimentalContracts::class)
+internal inline fun <reified T : IonValue> islRequireIonTypeNotNull(value: IonValue?, lazyMessage: () -> Any): T {
+    contract { returns() implies (value is T) }
+    if (value !is T || value.isNullValue) throw InvalidSchemaException(lazyMessage().toString())
+    return value
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Range.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Range.kt
@@ -80,6 +80,12 @@ internal fun checkRange(ion: IonList) {
             throw InvalidSchemaException("Invalid range, size of list must be 2:  $ion")
         ion[0].isNullValue || ion[1].isNullValue || (isRangeMin(ion[0]) && isRangeMax(ion[1])) ->
             throw InvalidSchemaException("Invalid range $ion")
+        ion[0].typeAnnotations.any { it != "exclusive" } || ion[1].typeAnnotations.any { it != "exclusive" } ->
+            throw InvalidSchemaException("Invalid range; unknown annotation(s) on range boundary: $ion")
+        isRangeMin(ion[0]) && ion[0].typeAnnotations.isNotEmpty() ->
+            throw InvalidSchemaException("Invalid range; 'min' may not be exclusive: $ion")
+        isRangeMax(ion[1]) && ion[1].typeAnnotations.isNotEmpty() ->
+            throw InvalidSchemaException("Invalid range; 'max' may not be exclusive: $ion")
     }
 }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/RangeIonTimestamp.kt
@@ -17,7 +17,6 @@ package com.amazon.ionschema.internal.util
 
 import com.amazon.ion.IonList
 import com.amazon.ion.IonTimestamp
-import com.amazon.ionschema.InvalidSchemaException
 
 /**
  * Implementation of Range<IonTimestamp> which mostly delegates to RangeBigDecimal.
@@ -37,11 +36,6 @@ internal class RangeIonTimestamp private constructor (
             newRange.addTypeAnnotation("range")
             ion.forEach { ionValue ->
                 val newValue = if (ionValue is IonTimestamp) {
-                    if (ionValue.localOffset == null) {
-                        throw InvalidSchemaException(
-                            "Timestamp range bound doesn't specify a local offset: $ionValue"
-                        )
-                    }
                     ion.system.newDecimal(ionValue.decimalMillis)
                 } else {
                     ionValue.clone()

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTests.kt
@@ -26,7 +26,7 @@ object IonSchemaTests {
 
     val TEST_CASE_ANNOTATIONS = arrayOf("\$test")
     val VALUE_TEST_CASE_FIELDS = setOf("type", "should_accept_as_valid", "should_reject_as_invalid")
-    val INVALID_SCHEMA_TEST_CASE_FIELDS = setOf("description", "invalid_schema")
+    val INVALID_SCHEMA_TEST_CASE_FIELDS = setOf("description", "invalid_schemas")
     val INVALID_TYPES_TEST_CASE_FIELDS = setOf("description", "invalid_types")
 
     /**
@@ -59,14 +59,14 @@ object IonSchemaTests {
             VALUE_TEST_CASE_FIELDS.containsAll(fieldNames)
     }
 
-    fun isInvalidSchemaTestCase(ion: IonStruct): Boolean {
+    fun isInvalidSchemasTestCase(ion: IonStruct): Boolean {
         return ion.typeAnnotations.contentEquals(TEST_CASE_ANNOTATIONS) &&
-            ion.fieldNameSet == INVALID_SCHEMA_TEST_CASE_FIELDS
+            ion.fieldNameSet.containsAll(INVALID_SCHEMA_TEST_CASE_FIELDS)
     }
 
     fun isInvalidTypesTestCase(ion: IonStruct): Boolean {
         return ion.typeAnnotations.contentEquals(TEST_CASE_ANNOTATIONS) &&
-            ion.fieldNameSet == INVALID_TYPES_TEST_CASE_FIELDS
+            ion.fieldNameSet.containsAll(INVALID_TYPES_TEST_CASE_FIELDS)
     }
 
     private val IonStruct.fieldNameSet: Set<String>

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/util/PreconditionsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/util/PreconditionsTest.kt
@@ -1,0 +1,159 @@
+package com.amazon.ionschema.internal.util
+
+import com.amazon.ion.IonInt
+import com.amazon.ion.IonValue
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class PreconditionsTest {
+
+    private val ion = IonSystemBuilder.standard().build()
+
+    @Nested
+    inner class islRequire {
+        @Test
+        fun `when value is true, should return normally`() {
+            islRequire(true) { "Message" }
+        }
+
+        @Test
+        fun `when value is false, should throw exception`() {
+            assertThrows<InvalidSchemaException> {
+                islRequire(false) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `compiler should infer things based on function contract`() {
+            val anyValue: Any = Unit
+            islRequire(anyValue is Unit) { "Message" }
+            // This is essentially a compile-time test. If the contract isn't working, then
+            // the compiler cannot make a smart cast of `anyValue` from Any to Unit.
+            return anyValue
+        }
+    }
+
+    @Nested
+    inner class islRequireNotNull {
+        @Test
+        fun `when value is not null, should return normally`() {
+            val maybeNull: Any? = Unit
+            val result = islRequireNotNull(maybeNull) { "Message" }
+            assertSame(maybeNull, result)
+        }
+
+        @Test
+        fun `when value is null, should throw exception`() {
+            val maybeNull: Any? = null
+            assertThrows<InvalidSchemaException> {
+                islRequireNotNull(maybeNull) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `compiler should infer things based on function contract`() {
+            val maybeNull: Unit? = Unit
+            islRequireNotNull(maybeNull) { "Message" }
+            // This is essentially a compile-time test. If the contract isn't working, then
+            // the compiler cannot make a smart cast of `maybeNull` from Unit? to Unit.
+            return maybeNull
+        }
+    }
+
+    @Nested
+    inner class islRequireIonNotNull {
+        @Test
+        fun `when value is not null, should return normally`() {
+            val maybeNull: IonValue? = ion.singleValue("1")
+            val result = islRequireIonNotNull(maybeNull) { "Message" }
+            assertSame(maybeNull, result)
+        }
+
+        @Test
+        fun `when value is an Ion null, should throw exception`() {
+            val maybeNull: IonValue? = ion.singleValue("null.int")
+            assertThrows<InvalidSchemaException> {
+                islRequireIonNotNull(maybeNull) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `when value is null, should throw exception`() {
+            val maybeNull: IonValue? = null
+            assertThrows<InvalidSchemaException> {
+                islRequireIonNotNull(maybeNull) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `compiler should infer things based on function contract`() {
+            val maybeNull: IonValue? = ion.singleValue("1")
+            islRequireIonNotNull(maybeNull) { "Message" }
+            // This is essentially a compile-time test. If the contract isn't working, then
+            // the compiler cannot make a smart cast of `maybeNull` from IonValue? to IonValue.
+            val notNull: IonValue = maybeNull
+        }
+    }
+
+    @Nested
+    inner class islRequireIonTypeNotNull {
+        @Test
+        fun `when value is correct Ion type and not null, should return normally`() {
+            val maybeIonInt: IonValue? = ion.singleValue("1")
+            val result = islRequireIonTypeNotNull<IonInt>(maybeIonInt) { "Message" }
+            assertSame(maybeIonInt, result)
+        }
+
+        @Test
+        fun `when value is wrong Ion type, should throw exception`() {
+            val maybeIonInt: IonValue? = ion.singleValue("1.0")
+            assertThrows<InvalidSchemaException> {
+                islRequireIonTypeNotNull<IonInt>(maybeIonInt) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `when value is an Ion null, should throw exception`() {
+            val maybeIonInt: IonValue? = ion.singleValue("null.int")
+            assertThrows<InvalidSchemaException> {
+                islRequireIonTypeNotNull<IonInt>(maybeIonInt) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `when value is null, should throw exception`() {
+            val maybeIonInt: IonValue? = null
+            assertThrows<InvalidSchemaException> {
+                islRequireIonTypeNotNull<IonInt>(maybeIonInt) { "Message" }
+            }.also {
+                assertEquals("Message", it.message)
+            }
+        }
+
+        @Test
+        fun `compiler should infer things based on function contract`() {
+            val maybeIonInt: IonValue? = ion.singleValue("1")
+            islRequireIonTypeNotNull<IonInt>(maybeIonInt) { "Message" }
+            // This is essentially a compile-time test. If the contract isn't working, then
+            // the compiler cannot make a smart cast of `maybeIonInt` from IonValue? to IonInt.
+            val ionInt: IonInt = maybeIonInt
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

#207 

*Description of changes:*

* Adds `SchemaImpl_2_0`. Rather than add a lot of branching into a single `Schema` implementation, I figured it would be more readable and easier to not make a mistake by having two separate implementations. I will not be duplicating everything—only things where there is substantially different logic to write. For now, the difference is that `SchemaImpl_2_0` has much stricter validations that `SchemaImpl_1_0` and it has no branches to support transitive imports. There still needs to be further work to support the `user_content` field in the schema header, and how transitive imports will (not) work with Ion Schema 1.0 schemas that use transitive imports.
* Renames `Annotations.kt` to `Annotations_1_0.kt`. This constraint is the only constraint where I think the logic diverges enough to justify a completely separate implementation.
* Adds `TypeOrNullDecorator` to support `$null_or`
* Adds support for most of the constraints that are basically unchanged from 1.0 to 2.0—logic constraints, length constraints, `contains`, `precision`, `timestamp_offset`, `timestamp_precision`, and `valid_values`.
* Updates `ion-schema-tests` submodule to the latest commit
* Updates the `IonSchemaTestsRunner` to handle `invalid_schemas` tests cases.
* Adds a test class for IonSchema 2.0 tests!
* Something kind of cool in this PR is that I'm using the Kotlin contract API for the first time. They are experimental, so they might need to be updated whenever we next upgrade the Kotlin version, but there's only a few of them, and they make the code more readable in other places by allowing the compiler to infer things about the type of a variable. (Here's [an introduction to Kotlin contracts](https://www.baeldung.com/kotlin/contracts) if you're interested in learning more.)

*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
