### PR TITLE
Adds support for Ion Schema 2.0 regex constraint

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -77,7 +77,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
         ConstraintConstructor("one_of", v1_0..v2_0, ::OneOf),
         ConstraintConstructor("ordered_elements", v1_0, ::OrderedElements),
         ConstraintConstructor("precision", v1_0..v2_0, ::Precision),
-        ConstraintConstructor("regex", v1_0, ::Regex),
+        ConstraintConstructor("regex", v1_0..v2_0) { ion, schema -> Regex(ion, schema.ionSchemaLanguageVersion) },
         ConstraintConstructor("scale", v1_0, ::Scale),
         ConstraintConstructor("timestamp_offset", v1_0..v2_0, ::TimestampOffset),
         ConstraintConstructor("timestamp_precision", v1_0..v2_0, ::TimestampPrecision),

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -45,6 +45,8 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
             it.path.endsWith("constraints/not.isl") ||
             // TODO: Add "one_of" tests once annotations support is added
             it.path.endsWith("constraints/precision.isl") ||
+            it.path.endsWith("constraints/regex.isl") ||
+            it.path.endsWith("constraints/regex-invalid.isl") ||
             it.path.endsWith("constraints/timestamp_offset.isl") ||
             it.path.endsWith("constraints/timestamp_precision.isl") ||
             it.path.endsWith("constraints/type.isl") ||


### PR DESCRIPTION
**Issue #, if available:**

#207 

**Description of changes:**

* Adds changes for regex constraint in Ion Schema 2.0—specifically, supporting character class meta-chars inside a user character class.
* Also fixes a bug where the Regex validator was not checking for a range quantifier with no lower bound, which would result in a `PatternSyntaxException` instead of an `InvalidSchemaException`
* Adds `regex` tests to the `IonSchemaTests_2_0` suite
* Updates `regex` in the constraint Factory to support ISL 2.0

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
Regex tests: https://github.com/amzn/ion-schema-tests/pull/31

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
