### PR TITLE
Adds support for Ion Schema 2.0 exponent constraint

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -29,6 +29,7 @@ import com.amazon.ionschema.internal.constraint.ContainerLength
 import com.amazon.ionschema.internal.constraint.Contains
 import com.amazon.ionschema.internal.constraint.Content
 import com.amazon.ionschema.internal.constraint.Element
+import com.amazon.ionschema.internal.constraint.Exponent
 import com.amazon.ionschema.internal.constraint.Fields
 import com.amazon.ionschema.internal.constraint.Not
 import com.amazon.ionschema.internal.constraint.OccursNoop
@@ -71,6 +72,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
         ConstraintConstructor("contains", v1_0..v2_0, ::Contains),
         ConstraintConstructor("content", v1_0, ::Content),
         ConstraintConstructor("element", v1_0, ::Element),
+        ConstraintConstructor("exponent", v2_0, ::Exponent),
         ConstraintConstructor("fields", v1_0, ::Fields),
         ConstraintConstructor("not", v1_0..v2_0, ::Not),
         ConstraintConstructor("occurs", v1_0, ::OccursNoop),

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Exponent.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Exponent.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ion.IonDecimal
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.Violation
+import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.util.RangeFactory
+import com.amazon.ionschema.internal.util.RangeType
+
+/**
+ * Implements the exponent constraint.
+ *
+ * @see https://amzn.github.io/ion-schema/docs/isl-2-0/spec#exponent
+ */
+internal class Exponent(
+    ion: IonValue
+) : ConstraintBase(ion) {
+
+    internal val range = RangeFactory.rangeOf<Int>(ion, RangeType.INT)
+
+    override fun validate(value: IonValue, issues: Violations) {
+        validateAs<IonDecimal>(value, issues) { v ->
+            @Suppress("UNCHECKED_CAST")
+            val exponent = v.bigDecimalValue().scale() * -1
+            if (!range.contains(exponent)) {
+                issues.add(Violation(ion, "invalid_exponent", "invalid exponent $exponent, expected $range"))
+            }
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -42,6 +42,7 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
             it.path.endsWith("constraints/codepoint_length.isl") ||
             it.path.endsWith("constraints/container_length.isl") ||
             it.path.endsWith("constraints/contains.isl") ||
+            it.path.endsWith("constraints/exponent.isl") ||
             it.path.endsWith("constraints/not.isl") ||
             // TODO: Add "one_of" tests once annotations support is added
             it.path.endsWith("constraints/precision.isl") ||


### PR DESCRIPTION
**Issue #, if available:**

#207

**Description of changes:**

* Adds the `exponent` constraint
* Adds exponent tests cases to `IonSchemaTests_2_0` suite

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

* `exponent` test cases https://github.com/amzn/ion-schema-tests/pull/29

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
