### PR TITLE
Adds support for Ion Schema 2.0 fields constraint

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -71,7 +71,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
         ConstraintConstructor("contains", v1_0..v2_0, ::Contains),
         ConstraintConstructor("content", v1_0, ::Content),
         ConstraintConstructor("element", v1_0, ::Element),
-        ConstraintConstructor("fields", v1_0, ::Fields),
+        ConstraintConstructor("fields", v1_0..v2_0, ::Fields),
         ConstraintConstructor("not", v1_0..v2_0, ::Not),
         ConstraintConstructor("occurs", v1_0, ::OccursNoop),
         ConstraintConstructor("one_of", v1_0..v2_0, ::OneOf),

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -42,6 +42,7 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
             it.path.endsWith("constraints/codepoint_length.isl") ||
             it.path.endsWith("constraints/container_length.isl") ||
             it.path.endsWith("constraints/contains.isl") ||
+            it.path.endsWith("constraints/fields.isl") ||
             it.path.endsWith("constraints/not.isl") ||
             // TODO: Add "one_of" tests once annotations support is added
             it.path.endsWith("constraints/precision.isl") ||


### PR DESCRIPTION
**Issue #, if available:**

#207

**Description of changes:**

* Adds support for Ion Schema 2.0 changes for `fields`—specifically, if version is ISL 2.0, check for the `closed::` annotation instead of `content: closed`, validate that no extra/illegal annotations are present.
* Duplicate field definitions have undefined behavior in Ion Schema 1.0 (spec and implementation) and they are explicitly prohibited in Ion Schema 2.0, so I went ahead and made the duplicate fields definition check apply to both versions. I think it's better to throw an exception than it is to leave the undefined behavior as is.
* Adds `fields` test cases to `IonSchemaTests_2_0` suite

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
* test cases https://github.com/amzn/ion-schema-tests/pull/30

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
