### PR TITLE
Adds support for Ion Schema 2.0 field_names constraint

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -30,6 +30,7 @@ import com.amazon.ionschema.internal.constraint.Contains
 import com.amazon.ionschema.internal.constraint.Content
 import com.amazon.ionschema.internal.constraint.Element
 import com.amazon.ionschema.internal.constraint.Exponent
+import com.amazon.ionschema.internal.constraint.FieldNames
 import com.amazon.ionschema.internal.constraint.Fields
 import com.amazon.ionschema.internal.constraint.Not
 import com.amazon.ionschema.internal.constraint.OccursNoop
@@ -73,6 +74,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
         ConstraintConstructor("content", v1_0, ::Content),
         ConstraintConstructor("element", v1_0, ::Element),
         ConstraintConstructor("exponent", v2_0, ::Exponent),
+        ConstraintConstructor("field_names", v2_0, ::FieldNames),
         ConstraintConstructor("fields", v1_0, ::Fields),
         ConstraintConstructor("not", v1_0..v2_0, ::Not),
         ConstraintConstructor("occurs", v1_0, ::OccursNoop),

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.Schema
+import com.amazon.ionschema.Violation
+import com.amazon.ionschema.ViolationChild
+import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.TypeReference
+
+/**
+ * Implements the field_names constraint.
+ * This constraint compares the text of all the field names in a struct against an ISL type.
+ *
+ * @see https://amzn.github.io/ion-schema/docs/isl-2-0/spec#field_names
+ */
+internal class FieldNames(ion: IonValue, schema: Schema) : ConstraintBase(ion) {
+
+    private val fieldNameType = TypeReference.create(ion.clone(), schema, isField = true, allowedAnnotations = setOf("distinct"))
+    private val requireDistinctValues: Boolean = ion.hasTypeAnnotation("distinct")
+
+    override fun validate(value: IonValue, issues: Violations) {
+
+        validateAs<IonStruct>(value, issues) { v ->
+
+            val fieldNameIssues = Violation(ion, "field_names_mismatch", "field names in struct do not meet expectations")
+            val distinctnessIssues = Violation(ion, "field_names_not_distinct", "one or more field names are duplicate values")
+
+            val invalidDuplicates = if (requireDistinctValues) v.map { it.fieldName }.notDistinct() else emptySet()
+
+            // For each field name, check if it matches the type reference and if it is in the set of duplicated field names.
+            v.sortedBy { it.fieldName }.forEach {
+
+                val fieldNameAsIonSymbol = it.system.newSymbol(it.fieldNameSymbol)
+
+                // Validate fieldNameAsIonSymbol against fieldNameType
+                val fieldNameValidation = ViolationChild(it.fieldName, value = fieldNameAsIonSymbol)
+                fieldNameType().validate(fieldNameAsIonSymbol, fieldNameValidation)
+                if (!fieldNameValidation.isValid()) {
+                    fieldNameIssues.add(fieldNameValidation)
+                }
+
+                // Is it a duplicate field name?
+                if (it.fieldName in invalidDuplicates) {
+                    distinctnessIssues.add(ViolationChild(it.fieldName, value = fieldNameAsIonSymbol))
+                }
+            }
+            if (!fieldNameIssues.isValid()) {
+                issues.add(fieldNameIssues)
+            }
+            if (!distinctnessIssues.isValid()) {
+                issues.add(distinctnessIssues)
+            }
+        }
+    }
+
+    /**
+     * Helper function to get a set of all elements in the original collection that are duplicated.
+     */
+    private fun <T> Iterable<T>.notDistinct(): Set<T> = groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -43,6 +43,7 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
             it.path.endsWith("constraints/container_length.isl") ||
             it.path.endsWith("constraints/contains.isl") ||
             it.path.endsWith("constraints/exponent.isl") ||
+            it.path.endsWith("constraints/field_names.isl") ||
             it.path.endsWith("constraints/not.isl") ||
             // TODO: Add "one_of" tests once annotations support is added
             it.path.endsWith("constraints/precision.isl") ||


### PR DESCRIPTION
**Issue #, if available:**

#207

**Description of changes:**

* Adds the `field_names` constraint
* Updates `IonSchemaTests_2_0` to include the `field_names` test cases

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

* test cases https://github.com/amzn/ion-schema-tests/pull/30
* spec https://amzn.github.io/ion-schema/docs/isl-2-0/spec#field_names

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
