### PR TITLE
Adds support for Ion Schema 2.0 annotations constraint

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -22,6 +22,7 @@ import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.internal.constraint.AllOf
 import com.amazon.ionschema.internal.constraint.Annotations_1_0
+import com.amazon.ionschema.internal.constraint.Annotations_2_0
 import com.amazon.ionschema.internal.constraint.AnyOf
 import com.amazon.ionschema.internal.constraint.ByteLength
 import com.amazon.ionschema.internal.constraint.CodepointLength
@@ -67,6 +68,7 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
     private val constraints = listOf(
         ConstraintConstructor("all_of", v1_0..v2_0, ::AllOf),
         ConstraintConstructor("annotations", v1_0, ::Annotations_1_0),
+        ConstraintConstructor("annotations", v2_0, ::Annotations_2_0),
         ConstraintConstructor("any_of", v1_0..v2_0, ::AnyOf),
         ConstraintConstructor("byte_length", v1_0..v2_0, ::ByteLength),
         ConstraintConstructor("codepoint_length", v1_0..v2_0, ::CodepointLength),

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ion.IonDatagram
+import com.amazon.ion.IonList
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.Schema
+import com.amazon.ionschema.Violation
+import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.CommonViolations
+import com.amazon.ionschema.internal.TypeInternal
+import com.amazon.ionschema.internal.TypeReference
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireIonNotNull
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+
+/**
+ * Implements the annotations constraint.
+ *
+ * @see https://amzn.github.io/ion-schema/docs/isl-2-0/spec#annotations
+ */
+internal class Annotations_2_0 constructor(
+    ion: IonValue,
+    schema: Schema,
+) : ConstraintBase(ion) {
+
+    private val type: () -> TypeInternal
+
+    companion object {
+        private val ALLOWED_MODIFIERS = setOf("closed", "required")
+    }
+
+    init {
+        type = if (ion is IonList) {
+            // This is the "simplified" syntax. In order to keep the validation from being complex, we convert
+            // from the "simplified" syntax to the standard syntax.
+
+            islRequireIonNotNull(ion) { "annotations list may not be null" }
+            islRequire(ion.typeAnnotations.isNotEmpty() && ion.typeAnnotations.all { it in ALLOWED_MODIFIERS }) {
+                "annotations list must be annotated only with one or both of 'closed', 'required'"
+            }
+
+            ion.onEach {
+                islRequireIonTypeNotNull<IonSymbol>(it) { "annotations list values must be non-null symbols" }
+                islRequire(it.typeAnnotations.isEmpty()) { "annotations list values may not be annotated" }
+            }
+
+            val annotationListTypeIon = ion.system.newEmptyStruct().apply {
+                if (ion.hasTypeAnnotation("closed")) {
+                    // May only contain...
+                    add(
+                        "element",
+                        ion.system.newEmptyStruct().apply {
+                            add("valid_values", ion.clone().apply { clearTypeAnnotations() })
+                        }
+                    )
+                }
+                if (ion.hasTypeAnnotation("required")) {
+                    // Must contain...
+                    add("contains", ion.clone().apply { clearTypeAnnotations() })
+                }
+            }
+
+            TypeReference.create(annotationListTypeIon, schema)
+        } else {
+            TypeReference.create(ion, schema, isField = true)
+        }
+    }
+
+    override fun validate(value: IonValue, issues: Violations) {
+        // Datagrams are always invalid for the `annotations` constraint because they don't have a list of annotations
+        if (value is IonDatagram) {
+            issues.add(CommonViolations.INVALID_TYPE(ion, value))
+            return
+        }
+        val annotationIssues = Violation(ion, "invalid_annotations", "annotations on value do not meet expectations")
+        type().validate(value.typeAnnotations.toIonSymbolList(), annotationIssues)
+        if (!annotationIssues.isValid()) {
+            issues.add(annotationIssues)
+        }
+    }
+
+    /**
+     * Helper function for taking a List or Array of [String] and turning it into an [IonList] of [IonSymbol]
+     */
+    private fun Array<String>.toIonSymbolList(): IonList {
+        val theSymbols = this.map { ion.system.newSymbol(it) }
+        return ion.system.newEmptyList().apply { addAll(theSymbols) }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -36,29 +36,7 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
     islVersion = v2_0,
     additionalFileFilter = {
         it.path.contains("ion_schema_2_0/schema/") ||
-            it.path.endsWith("constraints/all_of.isl") ||
-            it.path.endsWith("constraints/any_of.isl") ||
-            it.path.endsWith("constraints/byte_length.isl") ||
-            it.path.endsWith("constraints/codepoint_length.isl") ||
-            it.path.endsWith("constraints/container_length.isl") ||
-            it.path.endsWith("constraints/contains.isl") ||
-            it.path.endsWith("constraints/element.isl") ||
-            it.path.endsWith("constraints/exponent.isl") ||
-            it.path.endsWith("constraints/field_names.isl") ||
-            it.path.endsWith("constraints/fields.isl") ||
-            it.path.endsWith("constraints/ieee754_float.isl") ||
-            it.path.endsWith("constraints/not.isl") ||
-            // TODO: Add "one_of" tests once annotations support is added
-            it.path.endsWith("constraints/ordered_elements.isl") ||
-            it.path.endsWith("constraints/precision.isl") ||
-            it.path.endsWith("constraints/regex.isl") ||
-            it.path.endsWith("constraints/regex-invalid.isl") ||
-            it.path.endsWith("constraints/timestamp_offset.isl") ||
-            it.path.endsWith("constraints/timestamp_precision.isl") ||
-            it.path.endsWith("constraints/type.isl") ||
-            it.path.endsWith("constraints/utf8_byte_length.isl") ||
-            it.path.endsWith("constraints/valid_values.isl") ||
-            it.path.endsWith("constraints/valid_values-ranges.isl")
+            it.path.contains("ion_schema_2_0/constraints/")
     }
 )
 


### PR DESCRIPTION
**Issue #, if available:**

#207 

**Description of changes:**

* Adds an implementation of the `annotations` constraint for Ion Schema 2.0
* Updates the `IonSchemaTests_2_0` suite to include the `annotations` test cases

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

* Test cases created in https://github.com/amzn/ion-schema-tests/pull/30

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
