### PR TITLE
Adds support and validations for open content in Ion Schema 2.0

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaSystemBuilder.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaSystemBuilder.kt
@@ -34,7 +34,7 @@ class IonSchemaSystemBuilder private constructor() {
         @JvmStatic
         fun standard() = IonSchemaSystemBuilder()
 
-        private val defaultConstraintFactory = ConstraintFactoryDefault()
+        private val defaultConstraintFactory = ConstraintFactoryDefault
     }
 
     private var authorities = mutableListOf<Authority>()

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactoryDefault.kt
@@ -50,7 +50,7 @@ import com.amazon.ionschema.internal.constraint.ValidValues
 /**
  * Default [ConstraintFactory] implementation.
  */
-internal class ConstraintFactoryDefault : ConstraintFactory {
+internal object ConstraintFactoryDefault : ConstraintFactory {
 
     /**
      * Represents a mapping of (constraint name + supported ISL versions) to a constructor function
@@ -101,4 +101,11 @@ internal class ConstraintFactoryDefault : ConstraintFactory {
     override fun constraintFor(ion: IonValue, schema: Schema) = constraints
         .single { ion.fieldName == it.name && schema.ionSchemaLanguageVersion in it.versions }
         .newInstance(ion, schema)
+
+    /**
+     * Returns a list of constraint field names for the given [version].
+     */
+    fun getConstraintNamesForVersion(version: IonSchemaVersion): List<String> {
+        return constraints.filter { version in it.versions }.map { it.name }
+    }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -57,7 +57,8 @@ internal class SchemaImpl_2_0 private constructor(
 ) : SchemaImpl {
 
     /**
-     * Represents reserved words that the user is reserving for their own open content.
+     * Represents the collection of symbols that are declared as user reserved fields for a schema.
+     * See https://amzn.github.io/ion-schema/docs/isl-2-0/spec#open-content
      */
     private data class UserReservedFields(val headerWords: Set<String>, val typeWords: Set<String>, val footerWords: Set<String>) {
         companion object {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
@@ -23,8 +23,6 @@ import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.constraint.ConstraintBase
-import com.amazon.ionschema.internal.util.ISL_2_0_RESERVED_WORDS_REGEX
-import com.amazon.ionschema.internal.util.islRequire
 import com.amazon.ionschema.internal.util.markReadOnly
 
 /**
@@ -63,16 +61,7 @@ internal class TypeImpl(
             }
         }
 
-        if (schema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {
-            val illegalOpenContent = ionStruct.asSequence()
-                .map { it.fieldName }
-                .filterNotNull()
-                .filter { !(schema.getSchemaSystem() as IonSchemaSystemImpl).isConstraint(it, schema) }
-                .filter { !(it matches ISL_2_0_RESERVED_WORDS_REGEX) }
-                .toList()
-
-            islRequire(illegalOpenContent.isEmpty()) { "Illegal use of reserved words in a type definition: $illegalOpenContent" }
-        }
+        if (schema is SchemaImpl_2_0) schema.validateFieldNamesInType(ionStruct)
     }
 
     override val name = (ionStruct.get("name") as? IonSymbol)?.stringValue() ?: ionStruct.toString()

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0.kt
@@ -1,0 +1,42 @@
+package com.amazon.ionschema.internal.util
+
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.ConstraintFactoryDefault
+
+/**
+ * A collection of utilities that are specific to Ion Schema 2.0. This doesn't have to be an object, but wrapping
+ * these functions in an object conveniently namespaces them so that they can be referred to as [IonSchema_2_0.KEYWORDS], etc.
+ */
+internal object IonSchema_2_0 {
+    /**
+     * Keywords that are valid to use in a schema header
+     */
+    val HEADER_KEYWORDS = setOf("imports", "user_reserved_fields")
+
+    /**
+     * Keywords that could be valid to use in a type definition. Not all of these are valid in all type definitions.
+     * For example, `name` can only occur in top-level type definitions.
+     */
+    val TYPE_KEYWORDS = ConstraintFactoryDefault.getConstraintNamesForVersion(IonSchemaVersion.v2_0) + setOf("name", "occurs")
+
+    /**
+     * Keywords that are valid in an import.
+     */
+    val IMPORT_KEYWORDS = setOf("id", "type", "as")
+
+    /**
+     * Keywords that are valid as annotations on top-level types.
+     */
+    val TOP_LEVEL_ANNOTATION_KEYWORDS = setOf("schema_header", "schema_footer", "type")
+
+    /**
+     * All Ion Schema keywords.
+     */
+    val KEYWORDS = TOP_LEVEL_ANNOTATION_KEYWORDS + HEADER_KEYWORDS + TYPE_KEYWORDS + IMPORT_KEYWORDS
+
+    /**
+     * Regex to match symbols that are reserved in the Ion Schema specification.
+     * See https://amzn.github.io/ion-schema/docs/isl-2-0/spec#reserved-symbols
+     */
+    val RESERVED_WORDS_REGEX = Regex("(\\\$ion_schema(_.*)?|[a-z][a-z\\d]*(_[a-z\\d]+)*)")
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0_Util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0_Util.kt
@@ -1,6 +1,0 @@
-package com.amazon.ionschema.internal.util
-
-/**
- * See https://amzn.github.io/ion-schema/docs/isl-2-0/spec#reserved-symbols
- */
-internal val ISL_2_0_RESERVED_WORDS_REGEX = Regex("(\\\$ion_schema(_.*)?|[a-z][a-z\\d]*(_[a-z\\d]+)*)")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
@@ -15,12 +15,13 @@
 
 package com.amazon.ionschema.internal.util
 
-import com.amazon.ion.IonDatagram
-import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue
 
 /**
- * IonValue extension functions
+ * Returns `this` value, without annotations.
+ * If this value has no annotations, returns `this`;
+ * otherwise, returns a clone of `this` with the annotations removed.
  */
 internal fun IonValue.withoutTypeAnnotations() =
     if (typeAnnotations.isNotEmpty()) {
@@ -29,17 +30,17 @@ internal fun IonValue.withoutTypeAnnotations() =
         this
     }
 
-internal fun IonValue.markReadOnly(): IonValue {
-    this.makeReadOnly()
-    return this
+/**
+ * Gets all fields from a struct that have the given field name.
+ */
+internal fun IonStruct.getFields(fieldName: String): List<IonValue> {
+    return this.filter { it.fieldName == fieldName }
 }
 
-internal fun IonDatagram.markReadOnly(): IonDatagram {
-    this.makeReadOnly()
-    return this
-}
-
-internal fun IonSymbol.markReadOnly(): IonSymbol {
+/**
+ * Makes an IonValue instance read-only.
+ */
+internal fun <T : IonValue> T.markReadOnly(): T {
     this.makeReadOnly()
     return this
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
@@ -15,34 +15,80 @@
 
 package com.amazon.ionschema.internal.util
 
+import com.amazon.ion.IonContainer
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
+/**
+ * Checks a condition that is required for a Schema to be valid.
+ *
+ * @throws InvalidSchemaException if condition evaluates to false.
+ */
 @OptIn(ExperimentalContracts::class)
 internal inline fun islRequire(value: Boolean, lazyMessage: () -> Any) {
     contract { returns() implies value }
     if (!value) throw InvalidSchemaException(lazyMessage().toString())
 }
 
+/**
+ * Validates that a value is not (Kotlin) `null`.
+ *
+ * @throws InvalidSchemaException if [value] does not meet the above condition.
+ * @return [value]
+ */
 @OptIn(ExperimentalContracts::class)
 internal inline fun <reified T : Any> islRequireNotNull(value: T?, lazyMessage: () -> Any): T {
     contract { returns() implies (value is T) }
-    if (value !is T) throw InvalidSchemaException(lazyMessage().toString())
+    islRequire(value is T, lazyMessage)
     return value
 }
 
+/**
+ * Validates that an [IonValue] is not `null` or any Ion null.
+ *
+ * @throws InvalidSchemaException if [value] does not meet the above conditions.
+ * @return [value]
+ */
 @OptIn(ExperimentalContracts::class)
 internal inline fun <reified T : IonValue> islRequireIonNotNull(value: T?, lazyMessage: () -> Any): T {
     contract { returns() implies (value is T) }
-    if (value !is T || value.isNullValue) throw InvalidSchemaException(lazyMessage().toString())
+    islRequire(value is T && !value.isNullValue, lazyMessage)
     return value
 }
 
+/**
+ * Validates that an [IonValue] is not `null` or any Ion null, and that the value has Ion type [T].
+ *
+ * @throws InvalidSchemaException if [value] does not meet the above conditions.
+ * @return [value] as [T]
+ */
 @OptIn(ExperimentalContracts::class)
 internal inline fun <reified T : IonValue> islRequireIonTypeNotNull(value: IonValue?, lazyMessage: () -> Any): T {
     contract { returns() implies (value is T) }
-    if (value !is T || value.isNullValue) throw InvalidSchemaException(lazyMessage().toString())
+    islRequire(value is T && !value.isNullValue, lazyMessage)
     return value
+}
+
+/**
+ * Validates that this [Collection] has zero or one element(s).
+ *
+ * @throws InvalidSchemaException if this [Collection] does not meet the above condition.
+ * @return the only element, or `null`
+ */
+internal inline fun <T : Any> Collection<T>.islRequireZeroOrOneElements(lazyMessage: () -> Any): T? {
+    islRequire(this.size <= 1, lazyMessage)
+    return this.singleOrNull()
+}
+
+/**
+ * Validates that the given [IonContainer] has homogeneous elements of Ion type [T].
+ *
+ * @throws InvalidSchemaException if this [IonContainer] does not meet the above condition.
+ * @return the elements of [container] as `List<T>`
+ */
+internal inline fun <reified T : IonValue> islRequireElementType(container: IonContainer, allowNulls: Boolean = false, lazyMessage: () -> Any): List<T> {
+    islRequire(container.all { it is T && (allowNulls || !it.isNullValue) }, lazyMessage)
+    return container.filterIsInstance<T>()
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTests.kt
@@ -27,6 +27,7 @@ object IonSchemaTests {
     val TEST_CASE_ANNOTATIONS = arrayOf("\$test")
     val VALUE_TEST_CASE_FIELDS = setOf("type", "should_accept_as_valid", "should_reject_as_invalid")
     val INVALID_SCHEMA_TEST_CASE_FIELDS = setOf("description", "invalid_schemas")
+    val VALID_SCHEMA_TEST_CASE_FIELDS = setOf("description", "valid_schemas")
     val INVALID_TYPES_TEST_CASE_FIELDS = setOf("description", "invalid_types")
 
     /**
@@ -62,6 +63,11 @@ object IonSchemaTests {
     fun isInvalidSchemasTestCase(ion: IonStruct): Boolean {
         return ion.typeAnnotations.contentEquals(TEST_CASE_ANNOTATIONS) &&
             ion.fieldNameSet.containsAll(INVALID_SCHEMA_TEST_CASE_FIELDS)
+    }
+
+    fun isValidSchemasTestCase(ion: IonStruct): Boolean {
+        return ion.typeAnnotations.contentEquals(TEST_CASE_ANNOTATIONS) &&
+            ion.fieldNameSet.containsAll(VALID_SCHEMA_TEST_CASE_FIELDS)
     }
 
     fun isInvalidTypesTestCase(ion: IonStruct): Boolean {


### PR DESCRIPTION
**Issue #, if available:**

#207 

**Description of changes:**

* Adds support/validation for all aspects of open content in Ion Schema 2.0.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

Test cases:
https://github.com/amzn/ion-schema-tests/issues/39

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
