### PR TITLE
Adds Ion Schema 2.0 support for imports

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonSchema_2_0.kt
@@ -25,6 +25,11 @@ internal object IonSchema_2_0 {
     val IMPORT_KEYWORDS = setOf("id", "type", "as")
 
     /**
+     * Keywords that are valid in an inline import.
+     */
+    val INLINE_IMPORT_KEYWORDS = setOf("id", "type")
+
+    /**
      * Keywords that are valid as annotations on top-level types.
      */
     val TOP_LEVEL_ANNOTATION_KEYWORDS = setOf("schema_header", "schema_footer", "type")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
@@ -15,7 +15,7 @@
 
 package com.amazon.ionschema.internal.util
 
-import com.amazon.ion.IonContainer
+import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
 import kotlin.contracts.ExperimentalContracts
@@ -83,12 +83,132 @@ internal inline fun <T : Any> Collection<T>.islRequireZeroOrOneElements(lazyMess
 }
 
 /**
- * Validates that the given [IonContainer] has homogeneous elements of Ion type [T].
+ * Validates that all elements of an [Iterable] are of Ion type [T].
+ * If [allowAnnotations] is false, validates that all elements have no annotations.
+ * If [allowIonNulls] is false, validates that all elements are not an Ion null value.
  *
- * @throws InvalidSchemaException if this [IonContainer] does not meet the above condition.
- * @return the elements of [container] as `List<T>`
+ * @throws InvalidSchemaException if any element in the collection does not meet the above conditions.
+ * @return the elements of [this] as `Iterable<T>`
  */
-internal inline fun <reified T : IonValue> islRequireElementType(container: IonContainer, allowNulls: Boolean = false, lazyMessage: () -> Any): List<T> {
-    islRequire(container.all { it is T && (allowNulls || !it.isNullValue) }, lazyMessage)
-    return container.filterIsInstance<T>()
+internal inline fun <reified T : IonValue> Iterable<IonValue>.islRequireElementType(
+    containerDescription: String,
+    allowIonNulls: Boolean = false,
+    allowAnnotations: Boolean = false,
+): Iterable<T> {
+    this.onEach {
+        if (allowIonNulls) {
+            islRequire(it is T) { "$containerDescription elements must be a ${ionTypeDescription<T>()}: $this" }
+        } else {
+            islRequireIonTypeNotNull<T>(it) { "$containerDescription elements must be a non-null ${ionTypeDescription<T>()}: $this" }
+        }
+        if (!allowAnnotations) {
+            islRequire(it.typeAnnotations.isEmpty()) { "$containerDescription elements may not have annotations: $this" }
+        }
+    }
+    @Suppress("UNCHECKED_CAST")
+    return this as Iterable<T>
+}
+
+/**
+ * Validates that all elements of a [List] are of Ion type [T].
+ * If [allowAnnotations] is false, validates that all elements have no annotations.
+ * If [allowIonNulls] is false, validates that all elements are not an Ion null value.
+ *
+ * @throws InvalidSchemaException if any element in the collection does not meet the above conditions.
+ * @return the elements of [this] as `List<T>`
+ */
+internal inline fun <reified T : IonValue> List<IonValue>.islRequireElementType(
+    containerDescription: String,
+    allowIonNulls: Boolean = false,
+    allowAnnotations: Boolean = false,
+): List<T> = (this as Iterable<IonValue>).islRequireElementType<T>(
+    containerDescription,
+    allowIonNulls,
+    allowAnnotations,
+) as List<T>
+
+/**
+ * Gets a required field from an IonStruct, validating for type, nullability, and presence of annotations.
+ *
+ * Validates that a given field name is present in the struct exactly once, and that the corresponding field value is
+ * of type [T].
+ * If [allowAnnotations] is false, validates that the field value has no annotations.
+ * If [allowIonNulls] is false, validates that the field value is not an Ion null value.
+ *
+ * @throws InvalidSchemaException if this [IonStruct] does not contain exactly one element with the given field name
+ *      or if the element does not meet the required conditions.
+ * @return the value for the given field name
+ */
+internal inline fun <reified T : IonValue> IonStruct.getIslRequiredField(
+    fieldName: String,
+    allowIonNulls: Boolean = false,
+    allowAnnotations: Boolean = false,
+): T {
+    val theValue = getIslOptionalField<T>(fieldName, allowIonNulls, allowAnnotations)
+    return islRequireNotNull(theValue) { "missing required field '$fieldName': $this" }
+}
+
+/**
+ * Gets an optional field from an IonStruct, validating for type, nullability, and presence of annotations.
+ *
+ * Validates that a given field name is present in the struct zero or one times, and that the corresponding field value
+ * (if it exists) is of type [T].
+ * If [allowAnnotations] is false, validates that the field value has no annotations.
+ * If [allowIonNulls] is false, validates that the field value is not an Ion null value.
+ *
+ * If the field name does not occur in the struct, returns (Kotlin) `null`.
+ *
+ * @throws InvalidSchemaException if this [IonStruct] does not contain zero or one element with the given field name
+ *      or if the element does not meet the required conditions.
+ * @return the value for the given field name or null if no value has the given field name
+ */
+internal inline fun <reified T : IonValue> IonStruct.getIslOptionalField(
+    fieldName: String,
+    allowIonNulls: Boolean = false,
+    allowAnnotations: Boolean = false,
+): T? {
+    if (!this.containsKey(fieldName)) return null
+    val theValue = this.getFields(fieldName)
+        .also { islRequire(it.size == 1) { "field '$fieldName' may not occur more than once: $this" } }
+        .single()
+    if (allowIonNulls) {
+        islRequire(theValue is T) { "field must be a ${ionTypeDescription<T>()}; '$fieldName': $theValue" }
+    } else {
+        islRequireIonTypeNotNull<T>(theValue) { "field must be a non-null ${ionTypeDescription<T>()}; '$fieldName': $theValue" }
+    }
+    if (!allowAnnotations) {
+        islRequire(theValue.typeAnnotations.isEmpty()) { "field may not have annotations; '$fieldName': $theValue" }
+    }
+    return theValue
+}
+
+/**
+ * Converts an interface in the [IonValue] hierarchy into a prose-friendly name.
+ */
+private inline fun <reified T : IonValue> ionTypeDescription(): String {
+    return when (val name = T::class.simpleName?.removePrefix("Ion")?.toLowerCase()) {
+        null -> TODO("Unreachable")
+        "number" -> "int, float, or decimal"
+        "text" -> "string or symbol"
+        "sequence" -> "list or sexp"
+        "container" -> "struct, list, or sexp"
+        "lob" -> "blob or clob"
+        else -> name
+    }
+}
+
+/**
+ * Validates that an [IonStruct] contains no unexpected fields.
+ * @return [this]
+ * @throws InvalidSchemaException if any fields have a name not in [expectedFieldNames].
+ */
+internal fun IonStruct.islRequireOnlyExpectedFieldNames(
+    expectedFieldNames: Collection<String>,
+): IonStruct {
+    val unknownFields = this.filterNot { it.fieldName in expectedFieldNames }
+    if (unknownFields.isNotEmpty()) {
+        throw InvalidSchemaException("Unknown fields ${unknownFields.map { it.fieldName }} in struct: $this")
+    } else {
+        return this
+    }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -36,9 +36,8 @@ class IonSchemaTests_1_0 : TestFactory by IonSchemaTestsRunner(v1_0)
 class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
     islVersion = v2_0,
     additionalFileFilter = {
-        it.path.contains("ion_schema_2_0/schema/") ||
-            it.path.contains("ion_schema_2_0/constraints/") ||
-            it.path.contains("ion_schema_2_0/open_content/")
+        // Pending fix for https://github.com/amzn/ion-schema-kotlin/issues/209
+        !it.path.contains("cycles/")
     }
 )
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/util/PreconditionsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/util/PreconditionsTest.kt
@@ -1,14 +1,20 @@
 package com.amazon.ionschema.internal.util
 
+import com.amazon.ion.IonContainer
 import com.amazon.ion.IonInt
+import com.amazon.ion.IonList
+import com.amazon.ion.IonString
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionschema.InvalidSchemaException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
-import kotlin.test.assertSame
 
 class PreconditionsTest {
 
@@ -154,6 +160,228 @@ class PreconditionsTest {
             // This is essentially a compile-time test. If the contract isn't working, then
             // the compiler cannot make a smart cast of `maybeIonInt` from IonValue? to IonInt.
             val ionInt: IonInt = maybeIonInt
+        }
+    }
+
+    @Nested
+    inner class islRequireElementType {
+        @Test
+        fun `when collection is empty, should return empty list`() {
+            expectOk("[]") {
+                it.islRequireElementType<IonString>("a list")
+            }
+        }
+
+        @Test
+        fun `when collection has null value and nulls not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" [a, null.symbol, b] ") as IonList)
+                    .islRequireElementType<IonString>("my cool list")
+            }.also {
+                assertTrue("my cool list" in it.message!!)
+            }
+        }
+
+        @Test
+        fun `when collection has null value and nulls are allowed, should return normally`() {
+            expectOk(" [a, null.symbol, b] ") {
+                it.islRequireElementType<IonSymbol>("my cool list", allowIonNulls = true)
+            }
+        }
+
+        @Test
+        fun `when collection has annotated value and annotations not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" [a, foo::b, c] ") as IonList)
+                    .islRequireElementType<IonString>("my cool list")
+            }.also {
+                assertTrue("my cool list" in it.message!!)
+            }
+        }
+
+        @Test
+        fun `when collection has annotated value and annotations are allowed, should return normally`() {
+            expectOk(" [a, foo::b, c] ") {
+                it.islRequireElementType<IonSymbol>("my cool list", allowAnnotations = true)
+            }
+        }
+
+        private fun expectOk(ionText: String, fn: (Iterable<IonValue>) -> Iterable<IonValue>) {
+            val theList = (ion.singleValue(ionText) as IonContainer)
+            val result = fn(theList)
+            assertSame(theList, result)
+        }
+    }
+
+    @Nested
+    inner class getIslRequiredField {
+        @Test
+        fun `when field is right type, should return`() {
+            val result = (ion.singleValue(" {a:1} ") as IonStruct)
+                .getIslRequiredField<IonInt>("a")
+
+            assertEquals(1, result.intValue())
+        }
+
+        @Test
+        fun `when field is wrong type, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:1.23} ") as IonStruct)
+                    .getIslRequiredField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is not present, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:1} ") as IonStruct)
+                    .getIslRequiredField<IonInt>("b")
+            }
+        }
+
+        @Test
+        fun `when field is repeated, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:1, a:1} ") as IonStruct)
+                    .getIslRequiredField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is a null value and nulls not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:null.int} ") as IonStruct)
+                    .getIslRequiredField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is a null value and nulls are allowed, should return ion null`() {
+            val result = (ion.singleValue(" {a:null.int} ") as IonStruct)
+                .getIslRequiredField<IonInt>("a", allowIonNulls = true)
+
+            assertTrue(result.isNullValue)
+        }
+
+        @Test
+        fun `when field has annotations and annotations not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:foo::1} ") as IonStruct)
+                    .getIslRequiredField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field has annotations and annotations are allowed, should return`() {
+            val result = (ion.singleValue(" {a:foo::1} ") as IonStruct)
+                .getIslRequiredField<IonInt>("a", allowAnnotations = true)
+
+            assertTrue(result.hasTypeAnnotation("foo"))
+            assertEquals(1, result.intValue())
+        }
+    }
+
+    @Nested
+    inner class getIslOptionalField {
+        @Test
+        fun `when field is right type, should return`() {
+            val result = (ion.singleValue(" {a:1} ") as IonStruct)
+                .getIslOptionalField<IonInt>("a")
+
+            result!! // Asserts that result is not null
+            assertEquals(1, result.intValue())
+        }
+
+        @Test
+        fun `when field is wrong type, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:1.23} ") as IonStruct)
+                    .getIslOptionalField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is not present, should return null`() {
+            val result = (ion.singleValue(" {a:1} ") as IonStruct)
+                .getIslOptionalField<IonInt>("b")
+
+            assertEquals(null, result)
+        }
+
+        @Test
+        fun `when field is repeated, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:1, a:1} ") as IonStruct)
+                    .getIslOptionalField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is a null value and nulls not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:null.int} ") as IonStruct)
+                    .getIslOptionalField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field is a null value and nulls are allowed, should return ion null`() {
+            val result = (ion.singleValue(" {a:null.int} ") as IonStruct)
+                .getIslOptionalField<IonInt>("a", allowIonNulls = true)
+
+            result!! // Asserts that result is not null
+            assertTrue(result.isNullValue)
+        }
+
+        @Test
+        fun `when field has annotations and annotations not allowed, should throw`() {
+            assertThrows<InvalidSchemaException> {
+                (ion.singleValue(" {a:foo::1} ") as IonStruct)
+                    .getIslOptionalField<IonInt>("a")
+            }
+        }
+
+        @Test
+        fun `when field has annotations and annotations are allowed, should return`() {
+            val result = (ion.singleValue(" {a:foo::1} ") as IonStruct)
+                .getIslOptionalField<IonInt>("a", allowAnnotations = true)
+
+            result!! // Asserts that result is not null
+            assertTrue(result.hasTypeAnnotation("foo"))
+            assertEquals(1, result.intValue())
+        }
+    }
+
+    @Nested
+    inner class islRequireOnlyExpectedFieldNames {
+
+        @Test
+        fun `when no fields, should return normally`() {
+            val struct = (ion.singleValue("{}") as IonStruct)
+            val result = struct.islRequireOnlyExpectedFieldNames(listOf("a"))
+            assertSame(struct, result)
+        }
+
+        @Test
+        fun `when only expected fields, should return normally`() {
+            val struct = (ion.singleValue("{a:1}") as IonStruct)
+            val result = struct.islRequireOnlyExpectedFieldNames(listOf("a"))
+            assertSame(struct, result)
+        }
+
+        @Test
+        fun `when expected field is repeated, should return normally`() {
+            val struct = (ion.singleValue("{a:1, a:2}") as IonStruct)
+            val result = struct.islRequireOnlyExpectedFieldNames(listOf("a"))
+            assertSame(struct, result)
+        }
+
+        @Test
+        fun `when unexpected field is present, should throw`() {
+            val struct = (ion.singleValue("{a:1, b:2}") as IonStruct)
+            assertThrows<InvalidSchemaException> {
+                struct.islRequireOnlyExpectedFieldNames(listOf("a"))
+            }
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

#207 

**Description of changes:**

* Adds support for Ion Schema 2.0 imports
* Updates ion-schema-tests submodule to latest commit
* Adds several more validation helper functions to clean up the validations in `SchemaImpl_2_0`

Note that the CodeCov/patch report is failing because Jacoco doesn't understand how to measure code coverage for `inline` functions. (I've created https://github.com/amzn/ion-schema-kotlin/issues/221 to track fixing our code coverage reports.)

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

Tests were added in https://github.com/amzn/ion-schema-tests/pull/43

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
