### PR TITLE
Adds support for reading from stdin

### DIFF
--- a/ion-schema-cli
+++ b/ion-schema-cli
@@ -1,2 +1,13 @@
-#!/usr/bin/env sh
-./gradlew cli:install --quiet && exec cli/build/install/ion-schema-cli/bin/ion-schema-cli "$@"
+#!/usr/bin/env bash
+# This script is a wrapper for running the ion-schema-cli that ensures that
+# the latest changes are built every time you run the cli using this script.
+
+# `[ -t 0]` tests whether STDIN is a tty
+if [ -t 0 ]; then
+  ./gradlew cli:install --quiet && exec cli/build/install/ion-schema-cli/bin/ion-schema-cli "$@"
+else
+  # If STDIN is not TTY, then capture the data to prevent it from going to ./gradlew,
+  # and then re-send it before running the ion-schema-cli launcher script
+  DATA=$(cat)
+  ./gradlew cli:install --quiet && (echo "${DATA[@]}" | exec cli/build/install/ion-schema-cli/bin/ion-schema-cli "$@")
+fi


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Adds support for reading from `stdin` in a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) or piped from another command
* Adds machine-parseable output
* `type` is now an argument rather than an option (since it is/was always mandatory anyway)
* Adds option to slurp the input lines as a single input
* Adds option to suppress the output messages
* Adds option to have non-zero exit code when a value is invalid
* Refactors authority configuration so that you can have multiple authorities
* Makes ISL 2.0 the default version if not specified
* Adds a lot more examples and other info to `ion-schema-cli validate --help`

New `--help` output:
```
❯ ./ion-schema-cli validate --help
Usage: ion-schema-cli validate [OPTIONS] TYPE [IONDATA]...

  Validate Ion data for a given Ion Schema type.

Schema:

  All Ion Schema types are defined in the context of a schema document, so it
  is necessary to always have a schema document, even if that schema document
  is an implicit, empty schema. If a schema is not specified, the default is
  an implicit, empty Ion Schema 2.0 document.

  --id VALUE               The ID of a schema to load from one of the
                           configured authorities.
  -t, --schema-text VALUE  The Ion text contents of a schema document.
  -f, --schema-file VALUE  A schema file
  -v, --version VALUE      An empty schema document for the specified Ion
                           Schema version. The version must be specified as
                           X.Y; e.g. 2.0

Options:
  -a, --authority PATH   The root(s) of the file system authority(s).
                         Authorities are only required if you need to import a
                         type from another schema file or if you are loading a
                         schema using the --id option.
  -I, --isl-for-isl      Indicates that the Ion Schema Schemas authority
                         should be included in the schema system
                         configuration.
  -d, --document         Indicates that IONDATA should be interpreted as an
                         Ion document rather than as individual value(s).
  -s, --slurp            When reading from STDIN, indicates that lines should
                         be slurped together before parsing the Ion.
  -F, --fail-on-invalid  Sets the command to return a non-zero exit code when
                         a value is invalid for the given type.
  -q, --quiet            Suppress the validation results messages
  -h, --help             Show this message and exit

Arguments:
  TYPE     An ISL type name or inline type definition.
  IONDATA  Ion data to validate. If no value(s) are provided, this tool will
           attempt to read values from STDIN.

Example usage:

    Validate values for a type:
        ion-schema-cli validate '{ codepoint_length: 5, utf8_byte_length: range::[4,6] }' hello hello_world 1 '{:(:}'
    Output:
        valid::[]
        invalid::[{constraint:codepoint_length,code:invalid_codepoint_length,message:"invalid codepoint length 11, expected range::[5,5]"},{constraint:utf8_byte_length,code:invalid_utf8_byte_length,message:"invalid utf8 byte length 11, expected range::[4,6]"}]
        invalid::[{constraint:codepoint_length,code:invalid_type,message:"not applicable for type int"},{constraint:utf8_byte_length,code:invalid_type,message:"not applicable for type int"}]
        error::{type:"IonReaderTextParsingException",message:"unable to parse Ion: Syntax error at line 1 offset 3: invalid syntax [state:STATE_BEFORE_FIELD_NAME on token:TOKEN_COLON]"}

    Validate data for an inline-defined type:
        ion-schema-cli validate '{ codepoint_length: range::[min, 10] }' 'hello'

    Validate data for a type from a schema that is loaded from an authority:
        ion-schema-cli validate --authority ~/my_schemas/ --id 'Customers.isl' --type 'online_customer' '{ foo: bar }'

    Read multiple lines and validate as a single document:
        echo -e "hello \n world" | ./ion-schema-cli validate -ds  document

    Validate each line as a separate document:
        echo -e "hello \n world" | ./ion-schema-cli validate -d  document

    Validate each line as a single value:
        echo -e "hello \n world" | ./ion-schema-cli validate symbol

    Validate an ion file as a document:
        ion-schema-cli validate -ds -f ~/my_schemas/my_document_schema.isl my_specialized_document < my_data.ion

    Validate in REPL mode (use control-d to send EOF character and exit cleanly):
        ion-schema-cli validate '{ codepoint_length: 5 }'
```


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
