### PR TITLE
Fix default version of Ion Schema used by `ion-schema-cli validate`

### DIFF
--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/ValidateCommand.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/ValidateCommand.kt
@@ -116,7 +116,7 @@ class ValidateCommand : CliktCommand(
         help = "All Ion Schema types are defined in the context of a schema document, so it is necessary to always " +
             "have a schema document, even if that schema document is an implicit, empty schema. If a schema is " +
             "not specified, the default is an implicit, empty Ion Schema 2.0 document."
-    ).default { newSchema() }
+    ).default { newSchema(IonSchemaVersion.v2_0.symbolText) }
 
     private val type by argument(help = "An ISL type name or inline type definition.")
         .check(lazyMessage = { "Not a valid type reference: $it" }) {


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

The `ion-schema-cli validate` command behavior does not match the behavior described in `--help`—default Ion Schema version was 1.0 instead of 2.0. This PR fixes it by making it use ISl 2.0 by default.

*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*

None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
