### PR TITLE
Fix out-of-date packages breaking github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,10 @@ jobs:
           java-version: 11
       - run: ./gradlew koverXmlReport
       - name: Upload Ion Schema Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          file: ion-schema/build/reports/kover/report.xml
+          files: ion-schema/build/reports/kover/report.xml
       - name: Upload CLI Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          file: cli/build/reports/kover/report.xml
+          files: cli/build/reports/kover/report.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: corretto
           java-version: ${{ matrix.java }}
       - name: Cache Gradle packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
Addresses #309

## Description of changes

- Update `actions/cache` package in GitHub workflow to v4 from retired version.
- Update `codecov/codecov-action` package in GitHub workflow to v5 from v3 - avoids sporadic rate limiting issues with codecov.io's older APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
